### PR TITLE
[1.x] Add identifiers to rule builders

### DIFF
--- a/src/Rules/Debug/ChainedNoDebugInNamespaceRule.php
+++ b/src/Rules/Debug/ChainedNoDebugInNamespaceRule.php
@@ -33,7 +33,7 @@ class ChainedNoDebugInNamespaceRule extends BaseNoDebugRule implements Rule
         if ($message = $this->message($scope, 'App')) {
             return [
                 RuleErrorBuilder::message($message)
-                    ->identifier('hihaho.debug.noDebugInApp')
+                    ->identifier('hihaho.debug.noChainedDebugInApp')
                     ->build(),
             ];
         }
@@ -41,7 +41,7 @@ class ChainedNoDebugInNamespaceRule extends BaseNoDebugRule implements Rule
         if ($message = $this->message($scope, 'Test')) {
             return [
                 RuleErrorBuilder::message($message)
-                    ->identifier('hihaho.debug.noDebugInTests')
+                    ->identifier('hihaho.debug.noChainedDebugInTests')
                     ->build(),
             ];
         }

--- a/src/Rules/Debug/ChainedNoDebugInNamespaceRule.php
+++ b/src/Rules/Debug/ChainedNoDebugInNamespaceRule.php
@@ -32,13 +32,17 @@ class ChainedNoDebugInNamespaceRule extends BaseNoDebugRule implements Rule
 
         if ($message = $this->message($scope, 'App')) {
             return [
-                RuleErrorBuilder::message($message)->build(),
+                RuleErrorBuilder::message($message)
+                    ->identifier('hihaho.debug.no-debug-in-app')
+                    ->build(),
             ];
         }
 
         if ($message = $this->message($scope, 'Test')) {
             return [
-                RuleErrorBuilder::message($message)->build(),
+                RuleErrorBuilder::message($message)
+                    ->identifier('hihaho.debug.no-debug-in-tests')
+                    ->build(),
             ];
         }
 

--- a/src/Rules/Debug/ChainedNoDebugInNamespaceRule.php
+++ b/src/Rules/Debug/ChainedNoDebugInNamespaceRule.php
@@ -33,7 +33,7 @@ class ChainedNoDebugInNamespaceRule extends BaseNoDebugRule implements Rule
         if ($message = $this->message($scope, 'App')) {
             return [
                 RuleErrorBuilder::message($message)
-                    ->identifier('hihaho.debug.no-debug-in-app')
+                    ->identifier('hihaho.debug.noDebugInApp')
                     ->build(),
             ];
         }
@@ -41,7 +41,7 @@ class ChainedNoDebugInNamespaceRule extends BaseNoDebugRule implements Rule
         if ($message = $this->message($scope, 'Test')) {
             return [
                 RuleErrorBuilder::message($message)
-                    ->identifier('hihaho.debug.no-debug-in-tests')
+                    ->identifier('hihaho.debug.noDebugInTests')
                     ->build(),
             ];
         }

--- a/src/Rules/Debug/NoDebugInBladeRule.php
+++ b/src/Rules/Debug/NoDebugInBladeRule.php
@@ -48,7 +48,9 @@ class NoDebugInBladeRule extends BaseNoDebugRule implements Rule
 
         if ($message = sprintf($this->message, 'blade')) {
             return [
-                RuleErrorBuilder::message($message)->build(),
+                RuleErrorBuilder::message($message)
+                    ->identifier('hihaho.debug.no-debug-in-blade')
+                    ->build(),
             ];
         }
 

--- a/src/Rules/Debug/NoDebugInBladeRule.php
+++ b/src/Rules/Debug/NoDebugInBladeRule.php
@@ -49,7 +49,7 @@ class NoDebugInBladeRule extends BaseNoDebugRule implements Rule
         if ($message = sprintf($this->message, 'blade')) {
             return [
                 RuleErrorBuilder::message($message)
-                    ->identifier('hihaho.debug.no-debug-in-blade')
+                    ->identifier('hihaho.debug.noDebugInBlade')
                     ->build(),
             ];
         }

--- a/src/Rules/Debug/NoDebugInNamespaceRule.php
+++ b/src/Rules/Debug/NoDebugInNamespaceRule.php
@@ -43,13 +43,17 @@ class NoDebugInNamespaceRule extends BaseNoDebugRule implements Rule
 
         if ($message = $this->message($scope, 'App')) {
             return [
-                RuleErrorBuilder::message($message)->build(),
+                RuleErrorBuilder::message($message)
+                    ->identifier('hihaho.debug.no-debug-in-app')
+                    ->build(),
             ];
         }
 
         if ($message = $this->message($scope, 'Test')) {
             return [
-                RuleErrorBuilder::message($message)->build(),
+                RuleErrorBuilder::message($message)
+                    ->identifier('hihaho.debug.no-debug-in-tests')
+                    ->build(),
             ];
         }
 

--- a/src/Rules/Debug/NoDebugInNamespaceRule.php
+++ b/src/Rules/Debug/NoDebugInNamespaceRule.php
@@ -44,7 +44,7 @@ class NoDebugInNamespaceRule extends BaseNoDebugRule implements Rule
         if ($message = $this->message($scope, 'App')) {
             return [
                 RuleErrorBuilder::message($message)
-                    ->identifier('hihaho.debug.no-debug-in-app')
+                    ->identifier('hihaho.debug.noDebugInApp')
                     ->build(),
             ];
         }
@@ -52,7 +52,7 @@ class NoDebugInNamespaceRule extends BaseNoDebugRule implements Rule
         if ($message = $this->message($scope, 'Test')) {
             return [
                 RuleErrorBuilder::message($message)
-                    ->identifier('hihaho.debug.no-debug-in-tests')
+                    ->identifier('hihaho.debug.noDebugInTests')
                     ->build(),
             ];
         }

--- a/src/Rules/Debug/StaticChainedNoDebugInNamespaceRule.php
+++ b/src/Rules/Debug/StaticChainedNoDebugInNamespaceRule.php
@@ -32,13 +32,17 @@ class StaticChainedNoDebugInNamespaceRule extends BaseNoDebugRule implements Rul
 
         if ($message = $this->message($scope, 'App')) {
             return [
-                RuleErrorBuilder::message($message)->build(),
+                RuleErrorBuilder::message($message)
+                    ->identifier('hihaho.debug.no-debug-in-app')
+                    ->build(),
             ];
         }
 
         if ($message = $this->message($scope, 'Test')) {
             return [
-                RuleErrorBuilder::message($message)->build(),
+                RuleErrorBuilder::message($message)
+                    ->identifier('hihaho.debug.no-debug-in-tests')
+                    ->build(),
             ];
         }
 

--- a/src/Rules/Debug/StaticChainedNoDebugInNamespaceRule.php
+++ b/src/Rules/Debug/StaticChainedNoDebugInNamespaceRule.php
@@ -33,7 +33,7 @@ class StaticChainedNoDebugInNamespaceRule extends BaseNoDebugRule implements Rul
         if ($message = $this->message($scope, 'App')) {
             return [
                 RuleErrorBuilder::message($message)
-                    ->identifier('hihaho.debug.noDebugInApp')
+                    ->identifier('hihaho.debug.noStaticChainedDebugInApp')
                     ->build(),
             ];
         }
@@ -41,7 +41,7 @@ class StaticChainedNoDebugInNamespaceRule extends BaseNoDebugRule implements Rul
         if ($message = $this->message($scope, 'Test')) {
             return [
                 RuleErrorBuilder::message($message)
-                    ->identifier('hihaho.debug.noDebugInTests')
+                    ->identifier('hihaho.debug.noStaticChainedDebugInTests')
                     ->build(),
             ];
         }

--- a/src/Rules/Debug/StaticChainedNoDebugInNamespaceRule.php
+++ b/src/Rules/Debug/StaticChainedNoDebugInNamespaceRule.php
@@ -33,7 +33,7 @@ class StaticChainedNoDebugInNamespaceRule extends BaseNoDebugRule implements Rul
         if ($message = $this->message($scope, 'App')) {
             return [
                 RuleErrorBuilder::message($message)
-                    ->identifier('hihaho.debug.no-debug-in-app')
+                    ->identifier('hihaho.debug.noDebugInApp')
                     ->build(),
             ];
         }
@@ -41,7 +41,7 @@ class StaticChainedNoDebugInNamespaceRule extends BaseNoDebugRule implements Rul
         if ($message = $this->message($scope, 'Test')) {
             return [
                 RuleErrorBuilder::message($message)
-                    ->identifier('hihaho.debug.no-debug-in-tests')
+                    ->identifier('hihaho.debug.noDebugInTests')
                     ->build(),
             ];
         }

--- a/src/Rules/NamingClasses/EloquentApiResources.php
+++ b/src/Rules/NamingClasses/EloquentApiResources.php
@@ -56,7 +56,7 @@ class EloquentApiResources implements Rule
                 "Eloquent resource {$node->namespacedName->toString()} must be named with a `Resource` suffix, such as {$node->name->toString()}Resource."
             )
                 ->tip($this->tip())
-                ->identifier('hihaho.naming.classes.eloquent-api-resources')
+                ->identifier('hihaho.naming.classes.eloquentApiResources')
                 ->build(),
         ];
     }

--- a/src/Rules/NamingClasses/EloquentApiResources.php
+++ b/src/Rules/NamingClasses/EloquentApiResources.php
@@ -56,6 +56,7 @@ class EloquentApiResources implements Rule
                 "Eloquent resource {$node->namespacedName->toString()} must be named with a `Resource` suffix, such as {$node->name->toString()}Resource."
             )
                 ->tip($this->tip())
+                ->identifier('hihaho.naming.classes.eloquent-api-resources')
                 ->build(),
         ];
     }

--- a/src/Rules/NamingClasses/SuffixableRule.php
+++ b/src/Rules/NamingClasses/SuffixableRule.php
@@ -67,7 +67,7 @@ abstract class SuffixableRule implements Rule
                 "{$this->name()} {$node->namespacedName} must be named with a `{$this->suffix()}` suffix, such as {$node->name}{$this->suffix()}."
             )
                 ->tip($this->tip())
-                ->identifier('hihaho.naming.classes'. Str::of($this->name())->snake('-'))
+                ->identifier('hihaho.naming.classes' . Str::of($this->name())->snake('-'))
                 ->build(),
         ];
     }

--- a/src/Rules/NamingClasses/SuffixableRule.php
+++ b/src/Rules/NamingClasses/SuffixableRule.php
@@ -67,6 +67,7 @@ abstract class SuffixableRule implements Rule
                 "{$this->name()} {$node->namespacedName} must be named with a `{$this->suffix()}` suffix, such as {$node->name}{$this->suffix()}."
             )
                 ->tip($this->tip())
+                ->identifier('hihaho.naming.classes'. Str::of($this->name())->snake('-'))
                 ->build(),
         ];
     }

--- a/src/Rules/NamingClasses/SuffixableRule.php
+++ b/src/Rules/NamingClasses/SuffixableRule.php
@@ -67,7 +67,7 @@ abstract class SuffixableRule implements Rule
                 "{$this->name()} {$node->namespacedName} must be named with a `{$this->suffix()}` suffix, such as {$node->name}{$this->suffix()}."
             )
                 ->tip($this->tip())
-                ->identifier('hihaho.naming.classes' . Str::of($this->name())->snake('-'))
+                ->identifier('hihaho.naming.classes.' . $this->name())
                 ->build(),
         ];
     }

--- a/src/Rules/NoInvadeInAppCode.php
+++ b/src/Rules/NoInvadeInAppCode.php
@@ -29,7 +29,7 @@ class NoInvadeInAppCode implements Rule
                 RuleErrorBuilder::message(
                     'Usage of `\Livewire\invade` is disallowed, please use the global `invade` from spatie/invade.'
                 )
-                    ->identifier('hihaho.debug.disallowed-usage-of-livewire-invade')
+                    ->identifier('hihaho.debug.disallowedUsageOfLivewireInvade')
                     ->build(),
             ];
         }
@@ -46,7 +46,7 @@ class NoInvadeInAppCode implements Rule
             RuleErrorBuilder::message(
                 'Usage of method `invade` is not allowed in the App namespace.'
             )
-                ->identifier('hihaho.debug.no-invade-in-app-code')
+                ->identifier('hihaho.debug.noInvadeInAppCode')
                 ->build(),
         ];
     }

--- a/src/Rules/NoInvadeInAppCode.php
+++ b/src/Rules/NoInvadeInAppCode.php
@@ -28,7 +28,9 @@ class NoInvadeInAppCode implements Rule
             return [
                 RuleErrorBuilder::message(
                     'Usage of `\Livewire\invade` is disallowed, please use the global `invade` from spatie/invade.'
-                )->build(),
+                )
+                    ->identifier('hihaho.debug.disallowed-usage-of-livewire-invade')
+                    ->build(),
             ];
         }
 
@@ -43,7 +45,9 @@ class NoInvadeInAppCode implements Rule
         return [
             RuleErrorBuilder::message(
                 'Usage of method `invade` is not allowed in the App namespace.'
-            )->build(),
+            )
+                ->identifier('hihaho.debug.no-invade-in-app-code')
+                ->build(),
         ];
     }
 }

--- a/src/Rules/OnlyAllowFacadeAliasInBlade.php
+++ b/src/Rules/OnlyAllowFacadeAliasInBlade.php
@@ -48,7 +48,7 @@ class OnlyAllowFacadeAliasInBlade implements Rule
                 RuleErrorBuilder::message(
                     'Disallowed usage of `' . $node->class->toString() . '` facade alias, use `' . $reflected->getName() . '`. A facade alias can only be used in Blade.'
                 )
-                    ->identifier('hihaho.generic.only-allow-facade-alias-in-blade')
+                    ->identifier('hihaho.generic.onlyAllowFacadeAliasInBlade')
                     ->build(),
             ];
         }

--- a/src/Rules/OnlyAllowFacadeAliasInBlade.php
+++ b/src/Rules/OnlyAllowFacadeAliasInBlade.php
@@ -47,7 +47,9 @@ class OnlyAllowFacadeAliasInBlade implements Rule
             return [
                 RuleErrorBuilder::message(
                     'Disallowed usage of `' . $node->class->toString() . '` facade alias, use `' . $reflected->getName() . '`. A facade alias can only be used in Blade.'
-                )->build(),
+                )
+                    ->identifier('hihaho.generic.only-allow-facade-alias-in-blade')
+                    ->build(),
             ];
         }
 

--- a/src/Rules/Routing/RouteGroups.php
+++ b/src/Rules/Routing/RouteGroups.php
@@ -57,6 +57,7 @@ class RouteGroups implements Rule
                 'Route group options should be defined using methods.'
             )
                 ->tip($this->tip())
+                ->identifier('hihaho.routing.route-groups')
                 ->build(),
         ];
     }

--- a/src/Rules/Routing/RouteGroups.php
+++ b/src/Rules/Routing/RouteGroups.php
@@ -57,7 +57,7 @@ class RouteGroups implements Rule
                 'Route group options should be defined using methods.'
             )
                 ->tip($this->tip())
-                ->identifier('hihaho.routing.route-groups')
+                ->identifier('hihaho.routing.routeGroups')
                 ->build(),
         ];
     }

--- a/src/Rules/Routing/SlashInUrl.php
+++ b/src/Rules/Routing/SlashInUrl.php
@@ -62,7 +62,7 @@ class SlashInUrl implements Rule
                     'A route URL should be / instead of an empty string.'
                 )
                     ->tip($this->tip())
-                    ->identifier('hihaho.routing.no-empty-path')
+                    ->identifier('hihaho.routing.noEmptyPath')
                     ->build(),
             ];
         }
@@ -73,7 +73,7 @@ class SlashInUrl implements Rule
                     'A route URL should not start or end with /.'
                 )
                     ->tip($this->tip())
-                    ->identifier('hihaho.routing.no-leading-or-trailing-slash')
+                    ->identifier('hihaho.routing.noLeadingOrTrailingSlashInUrl')
                     ->build(),
             ];
         }

--- a/src/Rules/Routing/SlashInUrl.php
+++ b/src/Rules/Routing/SlashInUrl.php
@@ -62,6 +62,7 @@ class SlashInUrl implements Rule
                     'A route URL should be / instead of an empty string.'
                 )
                     ->tip($this->tip())
+                    ->identifier('hihaho.routing.no-empty-path')
                     ->build(),
             ];
         }
@@ -72,6 +73,7 @@ class SlashInUrl implements Rule
                     'A route URL should not start or end with /.'
                 )
                     ->tip($this->tip())
+                    ->identifier('hihaho.routing.no-leading-or-trailing-slash')
                     ->build(),
             ];
         }


### PR DESCRIPTION
Adds identifiers to all rules

These identifiers can then be used to ignore errors. Currently you'd need to use `@phpstan-ignore-next-line`, this will not run checks at all on this line. With identifiers we can exclude a certain rule, or rulesets. For example to ignore debug statements you can use the following:
```php
class Dumper
{
	public function dd()
	{
		/** @phpstan-ignore hihaho.debug.noDebugInApp */
		dd($this->value);
	}
}
```

See: https://phpstan.org/user-guide/ignoring-errors