### PR TITLE
[v2.0] Add PHP8.4 support & upgrade to PHPStan 2.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,11 @@
       branches:
         - main
     pull_request:
+      types:
+        - opened
+        - reopened
+        - synchronize
+        - ready_for_review
     workflow_dispatch:
 
   jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@
       strategy:
         fail-fast: true
         matrix:
-          php: [8.2, 8.3]
+          php: [8.2, 8.3, 8.4]
           laravel: [^10, ^11]
           stability: [prefer-lowest, prefer-stable]
 
@@ -31,7 +31,7 @@
 
         - name: Install dependencies
           run: |
-            composer require "illuminate/support:${{ matrix.laravel }}" --no-interaction --no-update
+            composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
             composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
         - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,9 +19,6 @@
           php: [8.2, 8.3, 8.4]
           laravel: [^10.48.23, ^11.31]
           stability: [prefer-lowest, prefer-stable]
-          exclude:
-            - laravel: ^10.48.23
-              stability: prefer-lowest
 
       name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.stability }}
 
@@ -39,7 +36,7 @@
 
         - name: Install dependencies
           run: |
-            composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
+            composer require "illuminate/support:${{ matrix.laravel }}" --no-interaction --no-update
             composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
         - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,9 @@
           php: [8.2, 8.3, 8.4]
           laravel: [^10.48.23, ^11.31]
           stability: [prefer-lowest, prefer-stable]
+          exclude:
+            - laravel: ^10.48.23
+              stability: prefer-lowest
 
       name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.stability }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@
         fail-fast: true
         matrix:
           php: [8.2, 8.3, 8.4]
-          laravel: [^10, ^11]
+          laravel: [^10.48.23, ^11.31]
           stability: [prefer-lowest, prefer-stable]
 
       name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.stability }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .phpunit.result.cache
 .phpunit.cache
 .idea
+.DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+## PHPStan indexing/analysis in PhpStorm
+
+PhpStorm might have issues indexing PHPStan due to .phar. To fix this, follow the steps below:
+
+1. **Open the Project in PhpStorm**.
+
+2. **Locate the `.idea/php.xml` file** in your project directory.
+
+3. **Edit the `php.xml` file** to include the path to `phpstan.phar`:
+
+    Add the following path inside the `<include_path>` section:
+    
+    ```xml
+    <path value="$PROJECT_DIR$/vendor/phpstan/phpstan/phpstan.phar" />
+    ```

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) Hihaho
+Copyright (c) hihaho
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,11 @@
         "illuminate/support": "^10.48.23|^11.31"
     },
     "require-dev": {
-        "laravel/framework": "^10.48.23|^11.31",
+        "illuminate/console": "^10.48.23|^11.31",
+        "illuminate/http": "^10.48.23|^11.31",
+        "illuminate/mail": "^10.48.23|^11.31",
+        "illuminate/notifications": "^10.48.23|^11.31",
+        "illuminate/routing": "^10.48.23|^11.31",
         "laravel/pint": "^1.13.9",
         "nikic/php-parser": "^5.0",
         "phpstan/extension-installer": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
     "require": {
         "php": "^8.2",
         "phpstan/phpstan": "^2.0",
-        "illuminate/support": "^10|^11"
+        "illuminate/support": "^10.48.23|^11.31"
     },
     "require-dev": {
-        "laravel/framework": "^10|^11",
+        "laravel/framework": "^10.48.23|^11.31",
         "laravel/pint": "^1.13.9",
         "nikic/php-parser": "^5.0",
         "phpstan/extension-installer": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -23,24 +23,26 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.2",
-        "phpstan/phpstan": "^1.10.55",
-        "illuminate/support": "^10|^11",
-        "laravel/pint": "^1.13.9"
+        "phpstan/phpstan": "^2.0",
+        "illuminate/support": "^10|^11"
     },
     "require-dev": {
-        "phpunit/phpunit": "^11.0",
+        "laravel/framework": "^10|^11",
+        "laravel/pint": "^1.13.9",
         "nikic/php-parser": "^5.0",
+        "phpstan/extension-installer": "^1.4",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpstan/phpstan-strict-rules": "^2.0",
+        "phpunit/phpunit": "^11.0",
+        "roave/security-advisories": "dev-latest",
         "spatie/invade": "^2.0",
-        "illuminate/http": "^10|^11",
-        "illuminate/console": "^10|^11",
-        "illuminate/mail": "^10|^11",
-        "illuminate/notifications": "^10|^11",
-        "illuminate/routing": "^10|^11",
-        "roave/security-advisories": "dev-latest"
+        "spaze/phpstan-disallowed-calls": "^4.0"
     },
     "scripts": {
         "test": "phpunit",
-        "fix-cs": "vendor/bin/pint"
+        "fix-cs": "vendor/bin/pint",
+        "phpstan": "vendor/bin/phpstan analyse -v"
     },
     "extra": {
         "phpstan": {
@@ -48,5 +50,11 @@
                 "extension.neon"
             ]
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "phpstan/extension-installer": true
+        },
+        "sort-packages": true
     }
 }

--- a/extension.neon
+++ b/extension.neon
@@ -36,10 +36,6 @@ services:
         tags:
             - phpstan.rules.rule
     -
-        class: Hihaho\PhpstanRules\Rules\Debug\NoDebugInBladeRule
-        tags:
-            - phpstan.rules.rule
-    -
         class: Hihaho\PhpstanRules\Rules\Debug\NoDebugInNamespaceRule
         tags:
             - phpstan.rules.rule

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,16 +1,2 @@
 parameters:
 	ignoreErrors:
-		-
-			message: "#^Access to an undefined property PhpParser\\\\Node\\:\\:\\$name\\.$#"
-			count: 1
-			path: src/Rules/Debug/ChainedNoDebugInNamespaceRule.php
-
-		-
-			message: "#^Access to an undefined property PhpParser\\\\Node\\:\\:\\$name\\.$#"
-			count: 1
-			path: src/Rules/Debug/NoDebugInNamespaceRule.php
-
-		-
-			message: "#^Access to an undefined property PhpParser\\\\Node\\:\\:\\$name\\.$#"
-			count: 1
-			path: src/Rules/Debug/StaticChainedNoDebugInNamespaceRule.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,9 @@
 includes:
-    - phpstan-baseline.neon
+    - phar://phpstan.phar/conf/bleedingEdge.neon
+    - ./phpstan-baseline.neon
+    - vendor/spaze/phpstan-disallowed-calls/disallowed-dangerous-calls.neon
+    - vendor/spaze/phpstan-disallowed-calls/disallowed-execution-calls.neon
+    - vendor/spaze/phpstan-disallowed-calls/disallowed-insecure-calls.neon
 
 parameters:
 
@@ -7,7 +11,10 @@ parameters:
         - src
         - tests
 
-    level: 3
+    level: max
+
+    strictRules:
+        allRules: false
 
     excludePaths:
         - tests/*/stubs/*

--- a/pint.json
+++ b/pint.json
@@ -36,6 +36,7 @@
         },
         "phpdoc_align": false,
         "phpdoc_separation": false,
+        "php_unit_method_casing": false,
         "function_typehint_space": false,
         "linebreak_after_opening_tag": false,
         "lowercase_static_reference": false,

--- a/pint.json
+++ b/pint.json
@@ -25,7 +25,6 @@
         "declare_strict_types": true,
         "single_space_around_construct": false,
         "statement_indentation": false,
-        "line_ending": false,
         "curly_braces_position": {
             "allow_single_line_anonymous_functions": false,
             "allow_single_line_empty_anonymous_classes": false,

--- a/pint.json
+++ b/pint.json
@@ -25,6 +25,7 @@
         "declare_strict_types": true,
         "single_space_around_construct": false,
         "statement_indentation": false,
+        "line_ending": false,
         "curly_braces_position": {
             "allow_single_line_anonymous_functions": false,
             "allow_single_line_empty_anonymous_classes": false,

--- a/src/Rules/Debug/StaticChainedNoDebugInNamespaceRule.php
+++ b/src/Rules/Debug/StaticChainedNoDebugInNamespaceRule.php
@@ -5,13 +5,12 @@ namespace Hihaho\PhpstanRules\Rules\Debug;
 use PhpParser\Node;
 use PhpParser\Node\Expr\StaticCall;
 use PHPStan\Analyser\Scope;
-use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 
 /**
- * @implements \PHPStan\Rules\Rule<StaticCall>
+ * @extends BaseNoDebugRule<\PhpParser\Node\Expr\StaticCall>
  */
-class StaticChainedNoDebugInNamespaceRule extends BaseNoDebugRule implements Rule
+class StaticChainedNoDebugInNamespaceRule extends BaseNoDebugRule
 {
     protected string $message = 'No statically called debug statements should be present in the %s namespace.';
 
@@ -20,30 +19,31 @@ class StaticChainedNoDebugInNamespaceRule extends BaseNoDebugRule implements Rul
         return StaticCall::class;
     }
 
+    /**
+     * @param StaticCall $node
+     */
     public function processNode(Node $node, Scope $scope): array
     {
         if (! $node->name instanceof Node\Identifier) {
             return [];
         }
 
-        if (! $this->hasDisallowedStatements($node->name->toString())) {
-            return [];
-        }
+        if ($this->isDisallowedStatement($node->name->toString())) {
+            if ($this->namespaceStartsWith($scope, 'App')) {
+                return [
+                    RuleErrorBuilder::message(sprintf($this->message, 'App'))
+                        ->identifier('hihaho.debug.noStaticChainedDebugInApp')
+                        ->build(),
+                ];
+            }
 
-        if ($message = $this->message($scope, 'App')) {
-            return [
-                RuleErrorBuilder::message($message)
-                    ->identifier('hihaho.debug.noStaticChainedDebugInApp')
-                    ->build(),
-            ];
-        }
-
-        if ($message = $this->message($scope, 'Test')) {
-            return [
-                RuleErrorBuilder::message($message)
-                    ->identifier('hihaho.debug.noStaticChainedDebugInTests')
-                    ->build(),
-            ];
+            if ($this->namespaceStartsWith($scope, 'Tests')) {
+                return [
+                    RuleErrorBuilder::message(sprintf($this->message, 'Tests'))
+                        ->identifier('hihaho.debug.noStaticChainedDebugInApp')
+                        ->build(),
+                ];
+            }
         }
 
         return [];

--- a/src/Rules/NamingClasses/EloquentApiResources.php
+++ b/src/Rules/NamingClasses/EloquentApiResources.php
@@ -2,12 +2,14 @@
 
 namespace Hihaho\PhpstanRules\Rules\NamingClasses;
 
+use App\Http\Resources\ChildVideo;
 use Hihaho\PhpstanRules\Traits\HasUrlTip;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Str;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 
@@ -19,6 +21,11 @@ class EloquentApiResources implements Rule
 {
     use HasUrlTip;
 
+    public function __construct(private readonly ReflectionProvider $reflectionProvider)
+    {
+        //
+    }
+
     public function docs(): string
     {
         return 'https://guidelines.hihaho.com/laravel.html#resources';
@@ -29,31 +36,42 @@ class EloquentApiResources implements Rule
         return Class_::class;
     }
 
+    /**
+     * @param Class_ $node
+     */
     public function processNode(Node $node, Scope $scope): array
     {
-        if (! $node instanceof Class_) {
-            return [];
-        }
-
         if (! $node->extends instanceof Node\Name) {
             return [];
         }
 
-        if (! Str::startsWith($node->namespacedName?->toString(), 'App\Http\Resources')) {
+        $nameSpacedName = $node->namespacedName?->toString();
+
+        if ($nameSpacedName === null) {
             return [];
         }
 
-        if ($node->extends->toString() !== JsonResource::class) {
+        if (! Str::startsWith($nameSpacedName, 'App\Http\Resources')) {
             return [];
         }
 
-        if (Str::endsWith($node->namespacedName->toString(), 'Resource')) {
+        if (Str::endsWith($nameSpacedName, 'Resource')) {
             return [];
         }
+
+        if ($this->reflectionProvider->hasClass($nameSpacedName)) {
+            $classReflection = $this->reflectionProvider->getClass($nameSpacedName);
+
+            if (! $classReflection->isSubclassOf(JsonResource::class)) {
+                return [];
+            }
+        }
+
+        $name = $node->name instanceof Node\Identifier ? $node->name->toString() : $nameSpacedName;
 
         return [
             RuleErrorBuilder::message(
-                "Eloquent resource {$node->namespacedName->toString()} must be named with a `Resource` suffix, such as {$node->name->toString()}Resource."
+                "Eloquent resource {$nameSpacedName} must be named with a `Resource` suffix, such as {$name}Resource."
             )
                 ->tip($this->tip())
                 ->identifier('hihaho.naming.classes.eloquentApiResources')

--- a/src/Rules/NamingClasses/EloquentApiResources.php
+++ b/src/Rules/NamingClasses/EloquentApiResources.php
@@ -2,7 +2,6 @@
 
 namespace Hihaho\PhpstanRules\Rules\NamingClasses;
 
-use App\Http\Resources\ChildVideo;
 use Hihaho\PhpstanRules\Traits\HasUrlTip;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Str;

--- a/src/Rules/NoInvadeInAppCode.php
+++ b/src/Rules/NoInvadeInAppCode.php
@@ -18,6 +18,9 @@ class NoInvadeInAppCode implements Rule
         return FuncCall::class;
     }
 
+    /**
+     * @param FuncCall $node
+     */
     public function processNode(Node $node, Scope $scope): array
     {
         if (! $node->name instanceof Node\Name) {
@@ -38,7 +41,9 @@ class NoInvadeInAppCode implements Rule
             return [];
         }
 
-        if (! str_starts_with($scope->getNamespace(), 'App')) {
+        $namespace = $scope->getNamespace();
+
+        if ($namespace === null || ! str_starts_with($namespace, 'App')) {
             return [];
         }
 

--- a/src/Rules/OnlyAllowFacadeAliasInBlade.php
+++ b/src/Rules/OnlyAllowFacadeAliasInBlade.php
@@ -20,6 +20,9 @@ class OnlyAllowFacadeAliasInBlade implements Rule
         return StaticCall::class;
     }
 
+    /**
+     * @param StaticCall $node
+     */
     public function processNode(Node $node, Scope $scope): array
     {
         if (! $node->class instanceof Node\Name) {
@@ -41,12 +44,13 @@ class OnlyAllowFacadeAliasInBlade implements Rule
             return [];
         }
 
-        $reflected = new \ReflectionClass($node->class->toCodeString());
+        // @phpstan-ignore phpstanApi.runtimeReflection, argument.type
+        $reflectionClass = new \ReflectionClass($node->class->toCodeString());
 
-        if ($reflected->isSubclassOf(Facade::class)) {
+        if ($reflectionClass->isSubclassOf(Facade::class)) {
             return [
                 RuleErrorBuilder::message(
-                    'Disallowed usage of `' . $node->class->toString() . '` facade alias, use `' . $reflected->getName() . '`. A facade alias can only be used in Blade.'
+                    "Disallowed usage of `{$node->class->toString()}` facade alias, use `{$reflectionClass->getName()}`. A facade alias can only be used in Blade."
                 )
                     ->identifier('hihaho.generic.onlyAllowFacadeAliasInBlade')
                     ->build(),

--- a/tests/Rules/Debug/NoChainedDebugInNamespaceTest.php
+++ b/tests/Rules/Debug/NoChainedDebugInNamespaceTest.php
@@ -7,6 +7,9 @@ use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\Test;
 
+/**
+ * @extends RuleTestCase<ChainedNoDebugInNamespaceRule>
+ */
 final class NoChainedDebugInNamespaceTest extends RuleTestCase
 {
     protected function getRule(): Rule
@@ -18,13 +21,13 @@ final class NoChainedDebugInNamespaceTest extends RuleTestCase
     public function should_not_contain_chained_debug_statements(): void
     {
         $this->analyse([__DIR__ . '/stubs/ChainedDebugInAppNamespaceStub.php'], [
-            ['No chained debug statements should be present in the app namespace.', 9],
-            ['No chained debug statements should be present in the app namespace.', 10],
+            ['No chained debug statements should be present in the App namespace.', 9],
+            ['No chained debug statements should be present in the App namespace.', 10],
         ]);
 
         $this->analyse([__DIR__ . '/stubs/ChainedDebugInTestNamespaceStub.php'], [
-            ['No chained debug statements should be present in the test namespace.', 9],
-            ['No chained debug statements should be present in the test namespace.', 10],
+            ['No chained debug statements should be present in the Tests namespace.', 9],
+            ['No chained debug statements should be present in the Tests namespace.', 10],
         ]);
     }
 }

--- a/tests/Rules/Debug/NoDebugInBladeTest.php
+++ b/tests/Rules/Debug/NoDebugInBladeTest.php
@@ -20,11 +20,13 @@ class NoDebugInBladeTest extends RuleTestCase
     #[Test]
     public function no_debug_statements_should_be_present_in_blade(): void
     {
-        $this->analyse([__DIR__ . '/stubs/debug-in-view-stub.blade.php'], [
-            [
-                'No debug directives should be present in blade files.',
-                1,
-            ],
-        ]);
+        self::markTestSkipped('Rule disabled, too performance heavy compared to looseness of check');
+//
+//        $this->analyse([__DIR__ . '/stubs/debug-in-view-stub.blade.php'], [
+//            [
+//                'No debug directives should be present in Blade files.',
+//                1,
+//            ],
+//        ]);
     }
 }

--- a/tests/Rules/Debug/NoDebugInNamespaceTest.php
+++ b/tests/Rules/Debug/NoDebugInNamespaceTest.php
@@ -22,15 +22,15 @@ class NoDebugInNamespaceTest extends RuleTestCase
     {
         $this->analyse([__DIR__ . '/stubs/DebugInAppNamespaceStub.php'], [
             [
-                'No debug statements should be present in the app namespace.',
+                'No debug statements should be present in the App namespace.',
                 12,
             ],
             [
-                'No debug statements should be present in the app namespace.',
+                'No debug statements should be present in the App namespace.',
                 13,
             ],
             [
-                'No debug statements should be present in the app namespace.',
+                'No debug statements should be present in the App namespace.',
                 14,
             ],
         ]);
@@ -41,15 +41,15 @@ class NoDebugInNamespaceTest extends RuleTestCase
     {
         $this->analyse([__DIR__ . '/stubs/DebugInTestNamespaceStub.php'], [
             [
-                'No debug statements should be present in the test namespace.',
+                'No debug statements should be present in the Tests namespace.',
                 12,
             ],
             [
-                'No debug statements should be present in the test namespace.',
+                'No debug statements should be present in the Tests namespace.',
                 13,
             ],
             [
-                'No debug statements should be present in the test namespace.',
+                'No debug statements should be present in the Tests namespace.',
                 14,
             ],
         ]);

--- a/tests/Rules/Debug/NoStaticChainedDebugInNamespaceTest.php
+++ b/tests/Rules/Debug/NoStaticChainedDebugInNamespaceTest.php
@@ -7,6 +7,9 @@ use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\Test;
 
+/**
+ * @extends RuleTestCase<StaticChainedNoDebugInNamespaceRule>
+ */
 final class NoStaticChainedDebugInNamespaceTest extends RuleTestCase
 {
     protected function getRule(): Rule
@@ -18,13 +21,13 @@ final class NoStaticChainedDebugInNamespaceTest extends RuleTestCase
     public function should_not_contain_static_called_debug_statements(): void
     {
         $this->analyse([__DIR__ . '/stubs/StaticChainedDebugInAppNamespaceStub.php'], [
-            ['No statically called debug statements should be present in the app namespace.', 11],
-            ['No statically called debug statements should be present in the app namespace.', 12],
+            ['No statically called debug statements should be present in the App namespace.', 11],
+            ['No statically called debug statements should be present in the App namespace.', 12],
         ]);
 
         $this->analyse([__DIR__ . '/stubs/StaticChainedDebugInTestNamespaceStub.php'], [
-            ['No statically called debug statements should be present in the test namespace.', 11],
-            ['No statically called debug statements should be present in the test namespace.', 12],
+            ['No statically called debug statements should be present in the Tests namespace.', 11],
+            ['No statically called debug statements should be present in the Tests namespace.', 12],
         ]);
     }
 }

--- a/tests/Rules/NamingClasses/EloquentApiResourcesTest.php
+++ b/tests/Rules/NamingClasses/EloquentApiResourcesTest.php
@@ -13,7 +13,7 @@ class EloquentApiResourcesTest extends RuleTestCase
 {
     protected function getRule(): Rule
     {
-        return new EloquentApiResources();
+        return new EloquentApiResources(self::createReflectionProvider());
     }
 
     public function testRule(): void
@@ -27,6 +27,16 @@ class EloquentApiResourcesTest extends RuleTestCase
         ]);
 
         $this->analyse([__DIR__ . '/stubs/resources/VideoResource.php'], []);
+
+        $this->analyse([__DIR__ . '/stubs/resources/ChildVideo.php'], [
+            [
+                'Eloquent resource App\Http\Resources\ChildVideo must be named with a `Resource` suffix, such as ChildVideoResource.',
+                5,
+                'Learn more at https://guidelines.hihaho.com/laravel.html#resources',
+            ],
+        ]);
+
+        $this->analyse([__DIR__ . '/stubs/resources/ChildVideoResource.php'], []);
 
         $this->analyse([__DIR__ . '/stubs/resources/RandomFile.php'], []);
     }

--- a/tests/Rules/NamingClasses/stubs/resources/ChildVideo.php
+++ b/tests/Rules/NamingClasses/stubs/resources/ChildVideo.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+class ChildVideo extends VideoResource
+{
+    //
+}

--- a/tests/Rules/NamingClasses/stubs/resources/ChildVideoResource.php
+++ b/tests/Rules/NamingClasses/stubs/resources/ChildVideoResource.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+class ChildVideoResource extends VideoResource
+{
+    //
+}

--- a/tests/Rules/NamingClasses/stubs/resources/RandomFile.php
+++ b/tests/Rules/NamingClasses/stubs/resources/RandomFile.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 class RandomFile
 {

--- a/tests/Rules/NamingClasses/stubs/resources/Video.php
+++ b/tests/Rules/NamingClasses/stubs/resources/Video.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 namespace App\Http\Resources;
 

--- a/tests/Rules/NamingClasses/stubs/resources/VideoResource.php
+++ b/tests/Rules/NamingClasses/stubs/resources/VideoResource.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 namespace App\Http\Resources;
 

--- a/tests/Rules/OnlyAllowFacadeAliasInBladeTest.php
+++ b/tests/Rules/OnlyAllowFacadeAliasInBladeTest.php
@@ -22,7 +22,7 @@ class OnlyAllowFacadeAliasInBladeTest extends RuleTestCase
         \Custom::class => Custom::class, // @phpstan-ignore-line
     ];
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Rules/OnlyAllowFacadeAliasInBladeTest.php
+++ b/tests/Rules/OnlyAllowFacadeAliasInBladeTest.php
@@ -1,9 +1,10 @@
 <?php declare(strict_types=1);
 
-namespace Rules\Routing\SlashInUrl;
+namespace tests\Rules;
 
 use App\Facades\Custom;
 use Hihaho\PhpstanRules\Rules\OnlyAllowFacadeAliasInBlade;
+use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\Route;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
@@ -13,7 +14,10 @@ use PHPStan\Testing\RuleTestCase;
  */
 class OnlyAllowFacadeAliasInBladeTest extends RuleTestCase
 {
-    protected $aliases = [
+    /**
+     * @var array<string, class-string<Facade>>
+     */
+    protected array $aliases = [
         \Route::class => Route::class, // @phpstan-ignore-line
         \Custom::class => Custom::class, // @phpstan-ignore-line
     ];
@@ -28,14 +32,10 @@ class OnlyAllowFacadeAliasInBladeTest extends RuleTestCase
         spl_autoload_register([$this, 'autoload'], throw: true, prepend: true);
     }
 
-    public function autoload(string $alias)
+    public function autoload(string $alias): void
     {
-        if ($alias === Custom::class) {
-            include 'stubs/CustomFacade.php';
-        }
-
         if (isset($this->aliases[$alias])) {
-            return class_alias($this->aliases[$alias], $alias);
+            class_alias($this->aliases[$alias], $alias);
         }
     }
 


### PR DESCRIPTION
This PR introduces several improvements and updates to enhance type safety, compatibility, and overall code quality:

- **PHP 8.4 Support**: Added support for PHP 8.4, ensuring compatibility with the latest PHP version.
- **Upgrade to PHPStan v2**: Updated to PHPStan v2, leveraging the latest features and improvements for more accurate type analysis.
- **Improved PHPStan Self-Coverage**: Enhanced internal type-checking by adding more precise type hints and refining type checks, improving the code's self-coverage with PHPStan.
- **Refined Type Handling**: Made type checks more specific, such as differentiating between `Node\Identifier` and `Node\Arg`, and improved handling of properties like `namespacedName` and `name`.
- **Code Simplification**: Removed redundant type checks, streamlined logic, and ensured clearer type definitions throughout the codebase.

These updates reduce complexity, improve type validation and maintainability.