### PR TITLE
Handle resource collections in rules/naming classes/eloquent api resources

### DIFF
--- a/src/Rules/NamingClasses/EloquentApiResources.php
+++ b/src/Rules/NamingClasses/EloquentApiResources.php
@@ -55,10 +55,6 @@ class EloquentApiResources implements Rule
             return [];
         }
 
-        if (Str::endsWith($nameSpacedName, ['Resource', 'ResourceCollection'])) {
-            return [];
-        }
-
         if (! $this->reflectionProvider->hasClass($nameSpacedName)) {
             return [];
         }
@@ -82,6 +78,10 @@ class EloquentApiResources implements Rule
                     ->identifier('hihaho.naming.classes.eloquentApiResourceCollections')
                     ->build(),
             ];
+        }
+
+        if (Str::endsWith($nameSpacedName, 'Resource')) {
+            return [];
         }
 
         if (! $classReflection->isSubclassOf(JsonResource::class)) {

--- a/tests/Rules/NamingClasses/EloquentApiResourcesTest.php
+++ b/tests/Rules/NamingClasses/EloquentApiResourcesTest.php
@@ -39,5 +39,15 @@ class EloquentApiResourcesTest extends RuleTestCase
         $this->analyse([__DIR__ . '/stubs/resources/ChildVideoResource.php'], []);
 
         $this->analyse([__DIR__ . '/stubs/resources/RandomFile.php'], []);
+
+        $this->analyse([__DIR__ . '/stubs/resources/VideoResourceCollection.php'], []);
+
+        $this->analyse([__DIR__ . '/stubs/resources/VideoCollection.php'], [
+            [
+                'Eloquent resource collection App\Http\Resources\VideoCollection must be named with a `ResourceCollection` suffix, such as VideoResourceCollection.',
+                7,
+                'Learn more at https://guidelines.hihaho.com/laravel.html#resources',
+            ],
+        ]);
     }
 }

--- a/tests/Rules/NamingClasses/stubs/resources/ChildVideoResourceCollection.php
+++ b/tests/Rules/NamingClasses/stubs/resources/ChildVideoResourceCollection.php
@@ -1,8 +1,0 @@
-<?php declare(strict_types=1);
-
-namespace App\Http\Resources;
-
-class ChildVideoResource extends VideoResource
-{
-    //
-}

--- a/tests/Rules/NamingClasses/stubs/resources/ChildVideoResourceCollection.php
+++ b/tests/Rules/NamingClasses/stubs/resources/ChildVideoResourceCollection.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+class ChildVideoResource extends VideoResource
+{
+    //
+}

--- a/tests/Rules/NamingClasses/stubs/resources/VideoCollection.php
+++ b/tests/Rules/NamingClasses/stubs/resources/VideoCollection.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class VideoCollection extends ResourceCollection
+{
+    //
+}

--- a/tests/Rules/NamingClasses/stubs/resources/VideoResourceCollection.php
+++ b/tests/Rules/NamingClasses/stubs/resources/VideoResourceCollection.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class VideoResourceCollection extends ResourceCollection
+{
+    //
+}


### PR DESCRIPTION
`VideoResourceCollection` should not get the suggestion to rename to `VideoResourceCollectionResource`, while `VideoCollection` should get the suggestion to rename to `VideoResourceCollection`