### PR TITLE
Harden GitHub Actions workflow security

### DIFF
--- a/.github/workflows/analyzer.yml
+++ b/.github/workflows/analyzer.yml
@@ -7,6 +7,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     runs-on: ubuntu-22.04
@@ -16,7 +19,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2
         with:
           php-version: 8.2
           coverage: none

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   pint:
     runs-on: ubuntu-22.04
@@ -14,7 +17,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2
         with:
           php-version: 8.2
           coverage: none

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run_tests:
     runs-on: ubuntu-22.04
@@ -30,7 +33,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2
         with:
           php-version: ${{ matrix.php }}
           coverage: none


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to all three workflows to enforce least-privilege
- Pin `shivammathur/setup-php` to commit SHA to prevent tag mutation attacks

Resolves all 6 open [CodeQL code scanning alerts](https://github.com/hihaho/phpstan-rules/security/code-scanning).

## Test plan
- [ ] Verify all three CI workflows (tests, phpstan, pint) pass on this PR


🤖 Generated with [Claude Code](https://claude.com/claude-code)