### PR TITLE
refactor: consolidate debug-detection wrappers into BaseNoDebugRule

### DIFF
--- a/src/Rules/CombinedFuncCallRule.php
+++ b/src/Rules/CombinedFuncCallRule.php
@@ -12,7 +12,6 @@ use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\IdentifierRuleError;
-use PHPStan\Rules\RuleErrorBuilder;
 
 /**
  * Combined rule that handles all FuncCall checks in a single PHPStan dispatch,
@@ -26,8 +25,6 @@ final readonly class CombinedFuncCallRule extends BaseNoDebugRule
 {
     use DetectsInvadeUsage;
     use DetectsUnsafeRequestHelper;
-
-    private const string DEBUG_MESSAGE = 'No debug statements should be present in the %s namespace.';
 
     /**
      * Quick-reject lookup: unqualified calls not in this set can be skipped without checking
@@ -88,7 +85,7 @@ final readonly class CombinedFuncCallRule extends BaseNoDebugRule
 
         $errors = [];
 
-        $debugError = $this->checkDebugStatement($funcName, $scope);
+        $debugError = $this->funcDebugError($funcName, $scope);
         if ($debugError instanceof IdentifierRuleError) {
             $errors[] = $debugError;
         }
@@ -104,22 +101,5 @@ final readonly class CombinedFuncCallRule extends BaseNoDebugRule
         }
 
         return $errors;
-    }
-
-    private function checkDebugStatement(string $funcName, Scope $scope): ?IdentifierRuleError
-    {
-        if (! $this->isDebugFunction($funcName)) {
-            return null;
-        }
-
-        $namespace = $this->matchDebugNamespace($scope);
-
-        if ($namespace === null) {
-            return null;
-        }
-
-        return RuleErrorBuilder::message(sprintf(self::DEBUG_MESSAGE, $namespace))
-            ->identifier("hihaho.debug.noDebugIn{$namespace}")
-            ->build();
     }
 }

--- a/src/Rules/CombinedMethodCallRule.php
+++ b/src/Rules/CombinedMethodCallRule.php
@@ -13,7 +13,6 @@ use PhpParser\Node\Identifier;
 use PHPStan\Analyser\Scope;
 use PHPStan\Parser\Parser;
 use PHPStan\Rules\IdentifierRuleError;
-use PHPStan\Rules\RuleErrorBuilder;
 
 /**
  * Combined rule that handles all MethodCall checks in a single PHPStan dispatch,
@@ -28,8 +27,6 @@ final readonly class CombinedMethodCallRule extends BaseNoDebugRule
     use DetectsPositionalFlagArgument;
     use DetectsUnsafeRequestData;
     use ResolvesFormRequestRuleKeys;
-
-    private const string DEBUG_MESSAGE = 'No chained debug statements should be present in the %s namespace.';
 
     /** @var array<string, true> */
     private array $unsafeMethodsLookup;
@@ -92,7 +89,7 @@ final readonly class CombinedMethodCallRule extends BaseNoDebugRule
             return $errors;
         }
 
-        $debugError = $this->checkDebugMethodCall($node, $methodName, $scope);
+        $debugError = $this->chainedDebugError($node, $methodName, $scope);
         if ($debugError instanceof IdentifierRuleError) {
             $errors[] = $debugError;
         }
@@ -108,26 +105,5 @@ final readonly class CombinedMethodCallRule extends BaseNoDebugRule
         }
 
         return $errors;
-    }
-
-    private function checkDebugMethodCall(MethodCall $node, string $methodName, Scope $scope): ?IdentifierRuleError
-    {
-        if (! $this->isDebugMethod($methodName)) {
-            return null;
-        }
-
-        $namespace = $this->matchDebugNamespace($scope);
-
-        if ($namespace === null) {
-            return null;
-        }
-
-        if (! $this->isDebugHelperMethodCall($node, $scope, $methodName)) {
-            return null;
-        }
-
-        return RuleErrorBuilder::message(sprintf(self::DEBUG_MESSAGE, $namespace))
-            ->identifier("hihaho.debug.noChainedDebugIn{$namespace}")
-            ->build();
     }
 }

--- a/src/Rules/CombinedStaticCallRule.php
+++ b/src/Rules/CombinedStaticCallRule.php
@@ -4,7 +4,6 @@ namespace Hihaho\PhpstanRules\Rules;
 
 use Hihaho\PhpstanRules\Rules\Debug\BaseNoDebugRule;
 use Hihaho\PhpstanRules\Traits\DetectsFacadeAlias;
-use Hihaho\PhpstanRules\Traits\DetectsLaravelStaticDebugCall;
 use Hihaho\PhpstanRules\Traits\DetectsPositionalFlagArgument;
 use Hihaho\PhpstanRules\Traits\DetectsUnsafeRequestFacade;
 use Illuminate\Support\Facades\Facade;
@@ -17,7 +16,6 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\IdentifierRuleError;
-use PHPStan\Rules\RuleErrorBuilder;
 
 /**
  * Combined rule that handles all StaticCall checks in a single PHPStan dispatch,
@@ -30,11 +28,8 @@ use PHPStan\Rules\RuleErrorBuilder;
 final readonly class CombinedStaticCallRule extends BaseNoDebugRule
 {
     use DetectsFacadeAlias;
-    use DetectsLaravelStaticDebugCall;
     use DetectsPositionalFlagArgument;
     use DetectsUnsafeRequestFacade;
-
-    private const string DEBUG_MESSAGE = 'No statically called debug statements should be present in the %s namespace.';
 
     private ?ClassReflection $facadeReflection;
 
@@ -96,7 +91,7 @@ final readonly class CombinedStaticCallRule extends BaseNoDebugRule
 
         $methodName = $node->name->name;
 
-        $debugError = $this->checkStaticDebugCall($node, $methodName, $scope);
+        $debugError = $this->staticDebugError($node, $methodName, $scope, $this->reflectionProvider, $this->facadeReflection);
         if ($debugError instanceof IdentifierRuleError) {
             $errors[] = $debugError;
         }
@@ -107,26 +102,5 @@ final readonly class CombinedStaticCallRule extends BaseNoDebugRule
         }
 
         return $errors;
-    }
-
-    private function checkStaticDebugCall(StaticCall $node, string $methodName, Scope $scope): ?IdentifierRuleError
-    {
-        if (! $this->isDebugMethod($methodName)) {
-            return null;
-        }
-
-        $namespace = $this->matchDebugNamespace($scope);
-
-        if ($namespace === null) {
-            return null;
-        }
-
-        if (! $this->isLaravelStaticDebugCall($node, $scope, $methodName, $this->reflectionProvider, $this->facadeReflection)) {
-            return null;
-        }
-
-        return RuleErrorBuilder::message(sprintf(self::DEBUG_MESSAGE, $namespace))
-            ->identifier("hihaho.debug.noStaticChainedDebugIn{$namespace}")
-            ->build();
     }
 }

--- a/src/Rules/Debug/BaseNoDebugRule.php
+++ b/src/Rules/Debug/BaseNoDebugRule.php
@@ -3,9 +3,15 @@
 namespace Hihaho\PhpstanRules\Rules\Debug;
 
 use Hihaho\PhpstanRules\Traits\ChecksNamespace;
+use Hihaho\PhpstanRules\Traits\DetectsLaravelStaticDebugCall;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
 
 /**
  * @template T of \PhpParser\Node
@@ -14,6 +20,7 @@ use PHPStan\Rules\Rule;
 abstract readonly class BaseNoDebugRule implements Rule
 {
     use ChecksNamespace;
+    use DetectsLaravelStaticDebugCall;
 
     /** @var array<string, true> */
     protected const array FUNCTION_DEBUG_STATEMENTS = [
@@ -40,6 +47,12 @@ abstract readonly class BaseNoDebugRule implements Rule
      * flagged.
      */
     protected const string LARAVEL_NAMESPACE_PREFIX = 'Illuminate\\';
+
+    private const string FUNC_DEBUG_MESSAGE = 'No debug statements should be present in the %s namespace.';
+
+    private const string CHAINED_DEBUG_MESSAGE = 'No chained debug statements should be present in the %s namespace.';
+
+    private const string STATIC_DEBUG_MESSAGE = 'No statically called debug statements should be present in the %s namespace.';
 
     final protected function isDebugFunction(string $statement): bool
     {
@@ -91,5 +104,81 @@ abstract readonly class BaseNoDebugRule implements Rule
         }
 
         return false;
+    }
+
+    /**
+     * Shared detection for a direct debug-function call (`dump(...)`,
+     * `dd(...)`, `print_r(...)`, …) inside the App/Tests namespaces. Used by
+     * both NoDebugInNamespaceRule and CombinedFuncCallRule.
+     */
+    final protected function funcDebugError(string $funcName, Scope $scope): ?IdentifierRuleError
+    {
+        if (! $this->isDebugFunction($funcName)) {
+            return null;
+        }
+
+        $namespace = $this->matchDebugNamespace($scope);
+
+        if ($namespace === null) {
+            return null;
+        }
+
+        return RuleErrorBuilder::message(sprintf(self::FUNC_DEBUG_MESSAGE, $namespace))
+            ->identifier("hihaho.debug.noDebugIn{$namespace}")
+            ->build();
+    }
+
+    /**
+     * Shared detection for a chained debug method call (`$x->dump()`) declared
+     * by a Laravel class/trait. Used by both ChainedNoDebugInNamespaceRule and
+     * CombinedMethodCallRule.
+     */
+    final protected function chainedDebugError(MethodCall $node, string $methodName, Scope $scope): ?IdentifierRuleError
+    {
+        if (! $this->isDebugMethod($methodName)) {
+            return null;
+        }
+
+        $namespace = $this->matchDebugNamespace($scope);
+
+        if ($namespace === null) {
+            return null;
+        }
+
+        if (! $this->isDebugHelperMethodCall($node, $scope, $methodName)) {
+            return null;
+        }
+
+        return RuleErrorBuilder::message(sprintf(self::CHAINED_DEBUG_MESSAGE, $namespace))
+            ->identifier("hihaho.debug.noChainedDebugIn{$namespace}")
+            ->build();
+    }
+
+    /**
+     * Shared detection for a statically called debug method (`Cache::dump()`)
+     * that proxies to a Laravel debug helper. Used by both
+     * StaticChainedNoDebugInNamespaceRule and CombinedStaticCallRule. The
+     * `$facadeReflection` is supplied by the caller (resolved once in its
+     * constructor) so this readonly hierarchy keeps no mutable state.
+     */
+    final protected function staticDebugError(StaticCall $node, string $methodName, Scope $scope, ReflectionProvider $reflectionProvider, ?ClassReflection $facadeReflection): ?IdentifierRuleError
+    {
+        if (! $this->isDebugMethod($methodName)) {
+            return null;
+        }
+
+        $namespace = $this->matchDebugNamespace($scope);
+
+        if ($namespace === null) {
+            return null;
+        }
+
+        if (! $this->isLaravelStaticDebugCall($node, $scope, $methodName, $reflectionProvider, $facadeReflection)) {
+            return null;
+        }
+
+        return RuleErrorBuilder::message(sprintf(self::STATIC_DEBUG_MESSAGE, $namespace))
+            ->identifier("hihaho.debug.noStaticChainedDebugIn{$namespace}")
+            ->build();
     }
 }

--- a/src/Rules/Debug/ChainedNoDebugInNamespaceRule.php
+++ b/src/Rules/Debug/ChainedNoDebugInNamespaceRule.php
@@ -8,15 +8,12 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\IdentifierRuleError;
-use PHPStan\Rules\RuleErrorBuilder;
 
 /**
  * @extends BaseNoDebugRule<MethodCall>
  */
 final readonly class ChainedNoDebugInNamespaceRule extends BaseNoDebugRule
 {
-    private const string MESSAGE = 'No chained debug statements should be present in the %s namespace.';
-
     #[Override]
     public function getNodeType(): string
     {
@@ -34,26 +31,8 @@ final readonly class ChainedNoDebugInNamespaceRule extends BaseNoDebugRule
             return [];
         }
 
-        $methodName = $node->name->name;
+        $error = $this->chainedDebugError($node, $node->name->name, $scope);
 
-        if (! $this->isDebugMethod($methodName)) {
-            return [];
-        }
-
-        $namespace = $this->matchDebugNamespace($scope);
-
-        if ($namespace === null) {
-            return [];
-        }
-
-        if (! $this->isDebugHelperMethodCall($node, $scope, $methodName)) {
-            return [];
-        }
-
-        return [
-            RuleErrorBuilder::message(sprintf(self::MESSAGE, $namespace))
-                ->identifier("hihaho.debug.noChainedDebugIn{$namespace}")
-                ->build(),
-        ];
+        return $error instanceof IdentifierRuleError ? [$error] : [];
     }
 }

--- a/src/Rules/Debug/NoDebugInNamespaceRule.php
+++ b/src/Rules/Debug/NoDebugInNamespaceRule.php
@@ -8,15 +8,12 @@ use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\IdentifierRuleError;
-use PHPStan\Rules\RuleErrorBuilder;
 
 /**
  * @extends BaseNoDebugRule<FuncCall>
  */
 final readonly class NoDebugInNamespaceRule extends BaseNoDebugRule
 {
-    private const string MESSAGE = 'No debug statements should be present in the %s namespace.';
-
     #[Override]
     public function getNodeType(): string
     {
@@ -34,26 +31,8 @@ final readonly class NoDebugInNamespaceRule extends BaseNoDebugRule
             return [];
         }
 
-        if (! $this->isDebugFunction($node->name->name)) {
-            return [];
-        }
+        $error = $this->funcDebugError($node->name->name, $scope);
 
-        if ($this->namespaceStartsWith($scope, 'App')) {
-            return [
-                RuleErrorBuilder::message(sprintf(self::MESSAGE, 'App'))
-                    ->identifier('hihaho.debug.noDebugInApp')
-                    ->build(),
-            ];
-        }
-
-        if ($this->namespaceStartsWith($scope, 'Tests')) {
-            return [
-                RuleErrorBuilder::message(sprintf(self::MESSAGE, 'Tests'))
-                    ->identifier('hihaho.debug.noDebugInTests')
-                    ->build(),
-            ];
-        }
-
-        return [];
+        return $error instanceof IdentifierRuleError ? [$error] : [];
     }
 }

--- a/src/Rules/Debug/StaticChainedNoDebugInNamespaceRule.php
+++ b/src/Rules/Debug/StaticChainedNoDebugInNamespaceRule.php
@@ -2,7 +2,6 @@
 
 namespace Hihaho\PhpstanRules\Rules\Debug;
 
-use Hihaho\PhpstanRules\Traits\DetectsLaravelStaticDebugCall;
 use Illuminate\Support\Facades\Facade;
 use Override;
 use PhpParser\Node;
@@ -12,17 +11,12 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\IdentifierRuleError;
-use PHPStan\Rules\RuleErrorBuilder;
 
 /**
  * @extends BaseNoDebugRule<StaticCall>
  */
 final readonly class StaticChainedNoDebugInNamespaceRule extends BaseNoDebugRule
 {
-    use DetectsLaravelStaticDebugCall;
-
-    private const string MESSAGE = 'No statically called debug statements should be present in the %s namespace.';
-
     private ?ClassReflection $facadeReflection;
 
     public function __construct(private ReflectionProvider $reflectionProvider)
@@ -49,26 +43,8 @@ final readonly class StaticChainedNoDebugInNamespaceRule extends BaseNoDebugRule
             return [];
         }
 
-        $methodName = $node->name->name;
+        $error = $this->staticDebugError($node, $node->name->name, $scope, $this->reflectionProvider, $this->facadeReflection);
 
-        if (! $this->isDebugMethod($methodName)) {
-            return [];
-        }
-
-        $namespace = $this->matchDebugNamespace($scope);
-
-        if ($namespace === null) {
-            return [];
-        }
-
-        if (! $this->isLaravelStaticDebugCall($node, $scope, $methodName, $this->reflectionProvider, $this->facadeReflection)) {
-            return [];
-        }
-
-        return [
-            RuleErrorBuilder::message(sprintf(self::MESSAGE, $namespace))
-                ->identifier("hihaho.debug.noStaticChainedDebugIn{$namespace}")
-                ->build(),
-        ];
+        return $error instanceof IdentifierRuleError ? [$error] : [];
     }
 }


### PR DESCRIPTION
## Summary

Removes the **last** twin/Combined duplication. The func / chained / static debug checks were the one set of rules still implemented twice — once in each standalone debug rule, once in its registered `Combined*` counterpart. This moves the three thin wrappers into `BaseNoDebugRule` (`funcDebugError`, `chainedDebugError`, `staticDebugError`), called by both sides, and absorbs the `DetectsLaravelStaticDebugCall` trait into the base so the static wrapper resolves cleanly (no per-rule trait `use`, no trait→base-method calls).

After this, **every** rule check has a single shared implementation; no twin can drift from its registered rule.

## Behaviour

Unchanged. Messages, identifiers (`hihaho.debug.noDebugIn{ns}` / `noChainedDebugIn{ns}` / `noStaticChainedDebugIn{ns}`), and namespace gating are identical. The func twin's previously-inlined App/Tests branches now route through the shared `matchDebugNamespace` helper — same output. No test was modified.

## Verification

- `vendor/bin/phpunit` — 205 pass / 261 assertions
- `vendor/bin/phpstan analyse` — 0 errors (level max, 100% type coverage)
- `vendor/bin/rector process` — 0 changes
- `vendor/bin/pint --test src tests` — clean

Net −47 lines (98 insertions / 145 deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)