### PR TITLE
feat: named-argument manifest producer + convention-faithful flag scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ $toggle->setActive('name', active: false);  // fine — already named
 
 This pairs with rector-rules' `FirstPartyFlagArgumentToNamedRector`, which auto-fixes the flags it can resolve with bare PHPStan. Because PHPStan rules inherit the consumer's extensions, this rule flags the rest in a larastan-equipped app — including receivers (generic or inherited properties) that rector cannot resolve. rector rewrites; this rule gates.
 
-Scope is deliberately tight (v1): the **last** argument only, and only when every argument is positional (no named or spread args), never a variadic parameter. Callee namespaces are configurable:
+Scope: the **last** argument only, and only when every argument is positional (no named or spread args); the matched parameter must be named and non-variadic. The parameter need **not** be bool-typed — a bare `null` on a `?Object` or `mixed` parameter is opaque too, matching the convention and the rector fixer (which names any bare flag without a type check). The gate is on the resolved member's **declaring** class, so an `App\` class inheriting a vendor method isn't flagged against vendor-declared, non-semver-stable parameter names. Callee namespaces are configurable:
 
 ```neon
 parameters:
@@ -212,6 +212,25 @@ parameters:
 ```
 
 Param names aren't semver-stable in vendor code, so only first-party callees are flagged.
+
+#### Named-argument manifest (opt-in producer)
+
+rector-rules' `NamedArgumentFromManifestRector` names these flags at call sites whose receiver only resolves under larastan — the sites bare-PHPStan auto-fixers can't reach. It is inert without a JSON manifest, which this package can produce: include the opt-in extension and run analysis in your larastan-equipped project.
+
+```neon
+includes:
+    - vendor/hihaho/phpstan-rules/named-argument-manifest.neon
+
+parameters:
+    namedArgumentManifest:
+        firstPartyNamespaces:
+            - App
+            - Database\Factories
+            - Tests
+        outputPath: named-arguments-manifest.json
+```
+
+`vendor/bin/phpstan analyse` then writes `named-arguments-manifest.json` — the same detection emitted as records (`{file, line, method, argIndex, paramName, value}`) instead of errors, with no CI errors raised. It is a PHPStan Collector, not an error formatter, so it is independent of the gate rules and unaffected by your baseline (baselined sites still appear in the manifest).
 
 ## Testing
 

--- a/named-argument-manifest.neon
+++ b/named-argument-manifest.neon
@@ -1,0 +1,38 @@
+# Opt-in producer for the named-argument manifest consumed by hihaho/rector-rules'
+# NamedArgumentFromManifestRector. Include this only when producing the manifest:
+#
+#   includes:
+#       - vendor/hihaho/phpstan-rules/named-argument-manifest.neon
+#
+# Then run `vendor/bin/phpstan analyse` (in a larastan-equipped project for full
+# coverage) — the manifest is written as a side artifact, no errors emitted. It
+# is independent of extension.neon's CI-gate rules.
+
+parametersSchema:
+    namedArgumentManifest: structure([
+        firstPartyNamespaces: listOf(string())
+        outputPath: string()
+    ])
+
+parameters:
+    namedArgumentManifest:
+        firstPartyNamespaces:
+            - App
+            - Database\Factories
+            - Tests
+        outputPath: named-arguments-manifest.json
+
+services:
+    -
+        class: Hihaho\PhpstanRules\Collectors\FlagArgumentManifestCollector
+        arguments:
+            reflectionProvider: @reflectionProvider
+            firstPartyNamespaces: %namedArgumentManifest.firstPartyNamespaces%
+        tags:
+            - phpstan.collector
+    -
+        class: Hihaho\PhpstanRules\Rules\Conventions\WriteNamedArgumentManifestRule
+        arguments:
+            outputPath: %namedArgumentManifest.outputPath%
+        tags:
+            - phpstan.rules.rule

--- a/src/Collectors/FlagArgumentManifestCollector.php
+++ b/src/Collectors/FlagArgumentManifestCollector.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+namespace Hihaho\PhpstanRules\Collectors;
+
+use Hihaho\PhpstanRules\Traits\DetectsPositionalFlagArgument;
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Expr\CallLike;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Collectors\Collector;
+use PHPStan\Reflection\ReflectionProvider;
+
+/**
+ * Collects positional bool/null flag-argument sites into manifest records for
+ * the sister rector rule (NamedArgumentFromManifestRector), which names them in
+ * a consumer's larastan-equipped run. Reuses the same detection core as the
+ * error rules — one implementation, two outputs (CI gate + manifest).
+ *
+ * @implements Collector<CallLike, array{line: int, method: string, argIndex: int, paramName: string, value: string}>
+ */
+final readonly class FlagArgumentManifestCollector implements Collector
+{
+    use DetectsPositionalFlagArgument;
+
+    /**
+     * @param  list<string>  $firstPartyNamespaces
+     */
+    public function __construct(
+        private ReflectionProvider $reflectionProvider,
+        private array $firstPartyNamespaces,
+    ) {}
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return CallLike::class;
+    }
+
+    /**
+     * @param  CallLike  $node
+     * @return array{line: int, method: string, argIndex: int, paramName: string, value: string}|null
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): ?array
+    {
+        $site = match (true) {
+            $node instanceof MethodCall => $this->flagSiteForMethodCall($node, $scope, $this->firstPartyNamespaces),
+            $node instanceof StaticCall => $this->flagSiteForStaticCall($node, $scope, $this->reflectionProvider, $this->firstPartyNamespaces),
+            $node instanceof New_ => $this->flagSiteForNew($node, $scope, $this->reflectionProvider, $this->firstPartyNamespaces),
+            default => null,
+        };
+
+        if ($site === null) {
+            return null;
+        }
+
+        return [
+            'line' => $node->getStartLine(),
+            'method' => $site['method'],
+            'argIndex' => $site['argIndex'],
+            'paramName' => $site['paramName'],
+            'value' => $site['value'],
+        ];
+    }
+}

--- a/src/Rules/Conventions/WriteNamedArgumentManifestRule.php
+++ b/src/Rules/Conventions/WriteNamedArgumentManifestRule.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types=1);
+
+namespace Hihaho\PhpstanRules\Rules\Conventions;
+
+use Hihaho\PhpstanRules\Collectors\FlagArgumentManifestCollector;
+use Override;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\CollectedDataNode;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+
+/**
+ * Writes the named-argument manifest from the data gathered by
+ * FlagArgumentManifestCollector. Runs once in the main process after analysis
+ * (the CollectedDataNode is the single post-analysis node), emits no errors —
+ * its only job is the JSON side artifact the sister rector rule consumes.
+ *
+ * @implements Rule<CollectedDataNode>
+ */
+final readonly class WriteNamedArgumentManifestRule implements Rule
+{
+    public function __construct(private string $outputPath) {}
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return CollectedDataNode::class;
+    }
+
+    /**
+     * @param  CollectedDataNode  $node
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $records = [];
+
+        foreach ($node->get(FlagArgumentManifestCollector::class) as $file => $fileRecords) {
+            $relativeFile = $this->toRootRelative($file);
+
+            foreach ($fileRecords as $record) {
+                $normalized = $this->normalizeRecord($record);
+
+                if ($normalized === null) {
+                    continue;
+                }
+
+                $records[] = ['file' => $relativeFile] + $normalized;
+            }
+        }
+
+        usort(
+            $records,
+            static fn (array $a, array $b): int => [$a['file'], $a['line'], $a['argIndex']] <=> [$b['file'], $b['line'], $b['argIndex']],
+        );
+
+        file_put_contents($this->outputPath, json_encode($records, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+
+        return [];
+    }
+
+    /**
+     * Validates a deserialized collected record (collector data crosses the
+     * worker→main boundary as plain arrays, so the type is not statically known).
+     *
+     * @return array{line: int, method: string, argIndex: int, paramName: string, value: string}|null
+     */
+    private function normalizeRecord(mixed $record): ?array
+    {
+        if (! is_array($record)
+            || ! isset($record['line'], $record['method'], $record['argIndex'], $record['paramName'], $record['value'])
+            || ! is_int($record['line'])
+            || ! is_string($record['method'])
+            || ! is_int($record['argIndex'])
+            || ! is_string($record['paramName'])
+            || ! is_string($record['value'])
+        ) {
+            return null;
+        }
+
+        return [
+            'line' => $record['line'],
+            'method' => $record['method'],
+            'argIndex' => $record['argIndex'],
+            'paramName' => $record['paramName'],
+            'value' => $record['value'],
+        ];
+    }
+
+    private function toRootRelative(string $file): string
+    {
+        $normalized = str_replace('\\', '/', $file);
+        $root = getcwd();
+
+        if ($root === false) {
+            return $normalized;
+        }
+
+        $root = str_replace('\\', '/', $root);
+
+        return str_starts_with($normalized, $root . '/')
+            ? substr($normalized, strlen($root) + 1)
+            : $normalized;
+    }
+}

--- a/src/Traits/DetectsPositionalFlagArgument.php
+++ b/src/Traits/DetectsPositionalFlagArgument.php
@@ -22,10 +22,16 @@ use PHPStan\Type\TypeCombinator;
  * argument of a first-party method, static, or constructor call — where naming
  * the argument (`paramName: false`) would make the call self-documenting.
  *
- * v1 scope: the last argument only, and only when every argument is positional
- * (no named or spread args), so the arg index maps directly to the parameter
- * index. This is the dominant case (`->getToken(..., false)`) and trailing-safe
- * by construction; the full trailing-run widening can come later.
+ * The detection core (`flagSiteFor*`) returns a `{method, argIndex, paramName,
+ * value}` record so it can drive both the error rules (CI gate) and the
+ * named-argument manifest Collector (rector producer) from one implementation.
+ *
+ * Scope: the last argument only, and only when every argument is positional (no
+ * named or spread args), so the arg index maps directly to the parameter index.
+ * Any bare flag on a named, non-variadic parameter qualifies — the parameter is
+ * NOT required to be bool-typed, matching the convention (a bare null on a
+ * `?Object`/`mixed` parameter is opaque too) and the sister rector fixer, which
+ * names bare flags without a type check.
  *
  * Type resolution uses whatever PHPStan extensions the consumer loads. In a
  * larastan-equipped app this resolves receivers (generic/inherited properties)
@@ -35,8 +41,9 @@ trait DetectsPositionalFlagArgument
 {
     /**
      * @param  list<string>  $firstPartyNamespaces
+     * @return array{method: string, argIndex: int, paramName: string, value: string}|null
      */
-    private function positionalFlagErrorForMethodCall(MethodCall $node, Scope $scope, array $firstPartyNamespaces): ?IdentifierRuleError
+    private function flagSiteForMethodCall(MethodCall $node, Scope $scope, array $firstPartyNamespaces): ?array
     {
         if (! $node->name instanceof Identifier) {
             return null;
@@ -53,18 +60,19 @@ trait DetectsPositionalFlagArgument
 
         // Single concrete receiver only (matches the sister rector rule). A union
         // receiver whose members name the flag parameter differently would make
-        // the suggested name ambiguous; cross-member agreement is v2 scope.
+        // the suggested name ambiguous; cross-member agreement is later scope.
         if (count($classReflections) !== 1 || ! $classReflections[0]->hasMethod($node->name->name)) {
             return null;
         }
 
-        return $this->flagError($classReflections[0]->getMethod($node->name->name, $scope), $args, $flagIndex, $scope, $firstPartyNamespaces);
+        return $this->flagRecord($classReflections[0]->getMethod($node->name->name, $scope), $node->name->name, $args, $flagIndex, $scope, $firstPartyNamespaces);
     }
 
     /**
      * @param  list<string>  $firstPartyNamespaces
+     * @return array{method: string, argIndex: int, paramName: string, value: string}|null
      */
-    private function positionalFlagErrorForStaticCall(StaticCall $node, Scope $scope, ReflectionProvider $reflectionProvider, array $firstPartyNamespaces): ?IdentifierRuleError
+    private function flagSiteForStaticCall(StaticCall $node, Scope $scope, ReflectionProvider $reflectionProvider, array $firstPartyNamespaces): ?array
     {
         if (! $node->class instanceof Name || ! $node->name instanceof Identifier) {
             return null;
@@ -89,13 +97,14 @@ trait DetectsPositionalFlagArgument
             return null;
         }
 
-        return $this->flagError($classReflection->getMethod($node->name->name, $scope), $args, $flagIndex, $scope, $firstPartyNamespaces);
+        return $this->flagRecord($classReflection->getMethod($node->name->name, $scope), $node->name->name, $args, $flagIndex, $scope, $firstPartyNamespaces);
     }
 
     /**
      * @param  list<string>  $firstPartyNamespaces
+     * @return array{method: string, argIndex: int, paramName: string, value: string}|null
      */
-    private function positionalFlagErrorForNew(New_ $node, Scope $scope, ReflectionProvider $reflectionProvider, array $firstPartyNamespaces): ?IdentifierRuleError
+    private function flagSiteForNew(New_ $node, Scope $scope, ReflectionProvider $reflectionProvider, array $firstPartyNamespaces): ?array
     {
         if (! $node->class instanceof Name) {
             return null;
@@ -120,7 +129,80 @@ trait DetectsPositionalFlagArgument
             return null;
         }
 
-        return $this->flagError($classReflection->getConstructor(), $args, $flagIndex, $scope, $firstPartyNamespaces);
+        // The rector rule keys constructor records on the resolved FQCN.
+        return $this->flagRecord($classReflection->getConstructor(), $className, $args, $flagIndex, $scope, $firstPartyNamespaces);
+    }
+
+    /**
+     * @param  list<string>  $firstPartyNamespaces
+     */
+    private function positionalFlagErrorForMethodCall(MethodCall $node, Scope $scope, array $firstPartyNamespaces): ?IdentifierRuleError
+    {
+        $site = $this->flagSiteForMethodCall($node, $scope, $firstPartyNamespaces);
+
+        return $site === null ? null : $this->flagError($site['paramName']);
+    }
+
+    /**
+     * @param  list<string>  $firstPartyNamespaces
+     */
+    private function positionalFlagErrorForStaticCall(StaticCall $node, Scope $scope, ReflectionProvider $reflectionProvider, array $firstPartyNamespaces): ?IdentifierRuleError
+    {
+        $site = $this->flagSiteForStaticCall($node, $scope, $reflectionProvider, $firstPartyNamespaces);
+
+        return $site === null ? null : $this->flagError($site['paramName']);
+    }
+
+    /**
+     * @param  list<string>  $firstPartyNamespaces
+     */
+    private function positionalFlagErrorForNew(New_ $node, Scope $scope, ReflectionProvider $reflectionProvider, array $firstPartyNamespaces): ?IdentifierRuleError
+    {
+        $site = $this->flagSiteForNew($node, $scope, $reflectionProvider, $firstPartyNamespaces);
+
+        return $site === null ? null : $this->flagError($site['paramName']);
+    }
+
+    /**
+     * Builds the shared `{method, argIndex, paramName, value}` record, gating on
+     * the member's declaring class (not the receiver) so an App\ class inheriting
+     * a vendor method is not named against vendor-declared, non-semver-stable
+     * parameter names.
+     *
+     * @param  array<Arg>  $args
+     * @param  list<string>  $firstPartyNamespaces
+     * @return array{method: string, argIndex: int, paramName: string, value: string}|null
+     */
+    private function flagRecord(ExtendedMethodReflection $method, string $methodLabel, array $args, int $flagIndex, Scope $scope, array $firstPartyNamespaces): ?array
+    {
+        if (! $this->isFirstPartyClass($method->getDeclaringClass()->getName(), $firstPartyNamespaces)) {
+            return null;
+        }
+
+        $parameters = ParametersAcceptorSelector::selectFromArgs($scope, $args, $method->getVariants())->getParameters();
+        $parameter = $parameters[$flagIndex] ?? null;
+
+        if ($parameter === null || $parameter->isVariadic()) {
+            return null;
+        }
+
+        return [
+            'method' => $methodLabel,
+            'argIndex' => $flagIndex,
+            'paramName' => $parameter->getName(),
+            'value' => $this->flagLiteral($args[$flagIndex]),
+        ];
+    }
+
+    private function flagError(string $paramName): IdentifierRuleError
+    {
+        return RuleErrorBuilder::message(sprintf(
+            'Pass a named argument (%s: ...) for the bool/null flag — it is opaque positionally.',
+            $paramName,
+        ))
+            ->identifier('hihaho.conventions.positionalFlagArgument')
+            ->tip('Name the flag at the call site so its meaning is visible: instead of foo(true), write foo(enabled: true).')
+            ->build();
     }
 
     /**
@@ -164,6 +246,11 @@ trait DetectsPositionalFlagArgument
         return in_array($arg->value->name->toLowerString(), ['true', 'false', 'null'], true);
     }
 
+    private function flagLiteral(Arg $arg): string
+    {
+        return $arg->value instanceof ConstFetch ? $arg->value->name->toLowerString() : '';
+    }
+
     /**
      * @param  list<string>  $namespaces
      */
@@ -176,40 +263,5 @@ trait DetectsPositionalFlagArgument
         }
 
         return false;
-    }
-
-    /**
-     * @param  array<Arg>  $args
-     * @param  list<string>  $firstPartyNamespaces
-     */
-    private function flagError(ExtendedMethodReflection $method, array $args, int $flagIndex, Scope $scope, array $firstPartyNamespaces): ?IdentifierRuleError
-    {
-        // Gate on where the member is DECLARED, not the receiver: an App\ class
-        // inheriting a vendor method would otherwise be flagged against
-        // vendor-declared parameter names, which are not semver-stable.
-        if (! $this->isFirstPartyClass($method->getDeclaringClass()->getName(), $firstPartyNamespaces)) {
-            return null;
-        }
-
-        $parameters = ParametersAcceptorSelector::selectFromArgs($scope, $args, $method->getVariants())->getParameters();
-        $parameter = $parameters[$flagIndex] ?? null;
-
-        if ($parameter === null || $parameter->isVariadic()) {
-            return null;
-        }
-
-        // Only a bool / ?bool parameter is a flag. A bare null passed to a
-        // nullable value type (?int, ?User) is not a flag, so skip it.
-        if (! TypeCombinator::removeNull($parameter->getType())->isBoolean()->yes()) {
-            return null;
-        }
-
-        return RuleErrorBuilder::message(sprintf(
-            'Pass a named argument (%s: ...) for the bool/null flag — it is opaque positionally.',
-            $parameter->getName(),
-        ))
-            ->identifier('hihaho.conventions.positionalFlagArgument')
-            ->tip('Name the flag at the call site so its meaning is visible: instead of foo(true), write foo(enabled: true).')
-            ->build();
     }
 }

--- a/tests/Rules/CombinedMethodCallRuleTest.php
+++ b/tests/Rules/CombinedMethodCallRuleTest.php
@@ -446,9 +446,12 @@ final class CombinedMethodCallRuleTest extends RuleTestCase
     }
 
     #[Test]
-    public function does_not_flag_a_null_passed_to_a_non_bool_nullable_parameter(): void
+    public function flags_a_bare_null_on_any_named_parameter_not_only_bool(): void
     {
-        $this->analyse([__DIR__ . '/Conventions/stubs/NonBoolNullArgStub.php'], []);
+        $this->analyse([__DIR__ . '/Conventions/stubs/NonBoolNullArgStub.php'], [
+            [$this->flagMessage('id'), 18, $this->flagTip()],
+            [$this->flagMessage('name'), 19, $this->flagTip()],
+        ]);
     }
 
     #[Test]

--- a/tests/Rules/Conventions/PositionalFlagArgumentMethodCallRuleTest.php
+++ b/tests/Rules/Conventions/PositionalFlagArgumentMethodCallRuleTest.php
@@ -47,9 +47,12 @@ final class PositionalFlagArgumentMethodCallRuleTest extends RuleTestCase
     }
 
     #[Test]
-    public function does_not_flag_a_null_passed_to_a_non_bool_nullable_parameter(): void
+    public function flags_a_bare_null_on_any_named_parameter_not_only_bool(): void
     {
-        $this->analyse([__DIR__ . '/stubs/NonBoolNullArgStub.php'], []);
+        $this->analyse([__DIR__ . '/stubs/NonBoolNullArgStub.php'], [
+            [$this->message('id'), 18, $this->tip()],
+            [$this->message('name'), 19, $this->tip()],
+        ]);
     }
 
     #[Test]

--- a/tests/Rules/Conventions/WriteNamedArgumentManifestRuleTest.php
+++ b/tests/Rules/Conventions/WriteNamedArgumentManifestRuleTest.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types=1);
+
+namespace Hihaho\PhpstanRules\Tests\Rules\Conventions;
+
+use Hihaho\PhpstanRules\Collectors\FlagArgumentManifestCollector;
+use Hihaho\PhpstanRules\Rules\Conventions\WriteNamedArgumentManifestRule;
+use Override;
+use PhpParser\Node;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * @extends RuleTestCase<WriteNamedArgumentManifestRule>
+ */
+final class WriteNamedArgumentManifestRuleTest extends RuleTestCase
+{
+    private string $manifestPath = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->manifestPath = (string) tempnam(sys_get_temp_dir(), 'phpstan-rules-manifest-');
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->manifestPath !== '' && file_exists($this->manifestPath)) {
+            unlink($this->manifestPath);
+        }
+
+        parent::tearDown();
+    }
+
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new WriteNamedArgumentManifestRule($this->manifestPath);
+    }
+
+    /**
+     * @return list<Collector<Node, mixed>>
+     */
+    #[Override]
+    protected function getCollectors(): array
+    {
+        return [
+            new FlagArgumentManifestCollector(
+                $this->createReflectionProvider(),
+                ['App', 'Database\\Factories', 'Tests'],
+            ),
+        ];
+    }
+
+    #[Test]
+    public function it_writes_records_for_method_call_flag_sites(): void
+    {
+        $this->analyse([__DIR__ . '/stubs/FlagMethodCallStub.php'], []);
+
+        $json = (string) file_get_contents($this->manifestPath);
+
+        $this->assertStringContainsString('FlagMethodCallStub.php', $json);
+        $this->assertStringContainsString('"method": "setActive"', $json);
+        $this->assertStringContainsString('"paramName": "active"', $json);
+        $this->assertStringContainsString('"value": "true"', $json);
+        $this->assertStringContainsString('"method": "configure"', $json);
+        $this->assertStringContainsString('"paramName": "option"', $json);
+        $this->assertStringContainsString('"value": "null"', $json);
+
+        // named, variadic, and non-last-flag sites must not be recorded.
+        $this->assertStringNotContainsString('"paramName": "text"', $json);
+        $this->assertStringNotContainsString('"paramName": "flags"', $json);
+    }
+
+    #[Test]
+    public function it_writes_records_for_static_and_constructor_flag_sites(): void
+    {
+        $this->analyse([
+            __DIR__ . '/stubs/StaticFlagCallStub.php',
+            __DIR__ . '/stubs/ConstructorFlagCallStub.php',
+        ], []);
+
+        $json = (string) file_get_contents($this->manifestPath);
+
+        // static call: StaticFlag::toggle('name', false)
+        $this->assertStringContainsString('"method": "toggle"', $json);
+        $this->assertStringContainsString('"paramName": "on"', $json);
+
+        // constructor: new Widget('name', true) — method is the resolved FQCN
+        $this->assertStringContainsString('App\\\\Models\\\\Widget', $json);
+        $this->assertStringContainsString('"paramName": "visible"', $json);
+    }
+}


### PR DESCRIPTION
## What

Adds an **opt-in producer** for [hihaho/rector-rules](https://github.com/hihaho/rector-rules)' `NamedArgumentFromManifestRector`, and makes the positional-flag rule **convention-faithful**.

The rector rule names positional `true`/`false`/`null` flags at call sites whose receiver only resolves under larastan — the gap bare-PHPStan auto-fixers (`FirstPartyFlagArgumentToNamedRector`) can't reach. It is inert without a JSON manifest. Nobody shipped a producer (hihaho PR #9870 was deferred for exactly this). This package already had the detection; this adds the manifest output.

## Changes

- **Shared detection core.** `DetectsPositionalFlagArgument` now exposes `flagSiteFor{MethodCall,StaticCall,New}` returning a `{method, argIndex, paramName, value}` record, driving both the error rules (CI gate) and the new Collector (manifest) from one implementation.
- **Producer (opt-in).** `FlagArgumentManifestCollector` (on `CallLike`) + `WriteNamedArgumentManifestRule` (on `CollectedDataNode`) write `named-arguments-manifest.json`, wired in a standalone `named-argument-manifest.neon`. It is a **Collector, not an error formatter** — so it is decoupled from the baseline (baselined sites still appear) and never hijacks `--error-format`.
- **Dropped the `bool/?bool` parameter guard.** The convention (PR #9745) and the rector fixer name **any** bare flag on a named parameter regardless of type; the guard excluded exactly the larastan-only `?Object`/`mixed` sites the manifest exists to cover. The error rule now flags those too (baseline if noisy). **Behaviour change** → minor bump.

## Schema

Verified against `NamedArgumentFromManifestRector` 0.9.x source: `file` (root-relative, fwd-slash), `line` (call-node start), `method` (name for method/static, FQCN for `new`), 0-based `argIndex`, `paramName`, `value` (lowercased literal drift guard).

## Verification

Rector 0 · Pint clean · PHPStan max 0 errors · 207 tests / 276 assertions. Producer smoke-tested end-to-end via the real neon (records match the pinned schema).

## Coordination

Three consumer/sister packages converged on this design (collectiq, mijntp, rector-rules); collectiq has removed its hand-rolled producer to adopt this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)