### PR TITLE
Add relation-existence closure builder type extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ conventions, see [`hihaho/rector-rules`](https://github.com/hihaho/rector-rules)
 
 - PHP 8.3 or higher
 - PHPStan 2.1 or higher
-- Laravel 12.x or 13.x (via `illuminate/support`)
+- Laravel 12.x or 13.x (via `illuminate/support` and `illuminate/database`)
 
 ## Installation
 
@@ -290,6 +290,33 @@ It is registered automatically — no configuration. Two guards keep it sound: d
 (the receiver must be a direct `->values()` call, so a chain split across variables is left alone
 rather than guessed), and the receiver must be a `Support\Collection`/`LazyCollection` (or subclass)
 — a bare `Enumerable` or a custom implementation with unknown key semantics is never narrowed.
+
+## Parameter closure type extensions
+
+### Relation-existence closure builder typing
+
+`RelationExistenceClosureBuilderParameterExtension` types the closure passed to Eloquent's
+relationship-existence methods (`whereHas`, `orWhereHas`, `whereDoesntHave`, `orWhereDoesntHave`,
+`has`, `orHas`, `doesntHave`, `orDoesntHave`) as the *related* model's builder. Laravel types the
+callback as `Closure(Builder<TRelatedModel>)`, but when the relation is passed as a string PHPStan
+cannot bind `TRelatedModel`, so it falls back to `Builder<Model>`. Under `checkModelProperties` that
+makes every `->where(RelatedModel::SOME_COLUMN)` inside the closure fail on valid columns.
+
+```php
+/** @param Builder<User> $query */
+public function scopeWithPublishedPosts(Builder $query): void
+{
+    // $q is Builder<Post> — Post::PUBLISHED resolves instead of erroring against base Model.
+    $query->whereHas('posts', fn (Builder $q) => $q->where(Post::STATUS, Post::PUBLISHED));
+}
+```
+
+It is registered automatically — no configuration. The closure parameter needs no annotation (a bare
+`Builder` hint is narrowed in place), arrow functions are preserved, dotted nested relations
+(`'posts.comments'`) resolve to the last related model, and a related model with a custom builder
+(`HasBuilder`/`newEloquentBuilder()`) keeps that builder type. It fails safe: when the model or
+relation can't be proven (dynamic relation name, unknown relation), the default typing stands, so a
+genuinely wrong column on the correct related model still fails.
 
 ## Testing
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
             "tests/Rules/stubs/",
             "tests/Rules/Debug/stubs/",
             "tests/Rules/Validation/stubs/",
-            "tests/Rules/Conventions/stubs/"
+            "tests/Rules/Conventions/stubs/",
+            "tests/ParameterClosureTypes/stubs/"
         ],
         "exclude-from-classmap": [
             "tests/Rules/stubs/facade-alias-in-view.blade.php"
@@ -36,6 +37,7 @@
     "require": {
         "php": "^8.3",
         "phpstan/phpstan": "^2.1.8",
+        "illuminate/database": "^12.0||^13.0",
         "illuminate/support": "^12.0||^13.0"
     },
     "require-dev": {

--- a/extension.neon
+++ b/extension.neon
@@ -125,3 +125,9 @@ services:
         class: Hihaho\PhpstanRules\ReturnTypes\CollectionListAllReturnTypeExtension
         tags:
             - phpstan.broker.dynamicMethodReturnTypeExtension
+    -
+        class: Hihaho\PhpstanRules\ParameterClosureTypes\RelationExistenceClosureBuilderParameterExtension
+        arguments:
+            reflectionProvider: @reflectionProvider
+        tags:
+            - phpstan.methodParameterClosureTypeExtension

--- a/src/ParameterClosureTypes/ClosureParameter.php
+++ b/src/ParameterClosureTypes/ClosureParameter.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace Hihaho\PhpstanRules\ParameterClosureTypes;
+
+use Override;
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Reflection\PassedByReference;
+use PHPStan\Type\Type;
+
+/**
+ * Minimal ParameterReflection for describing a single closure parameter in a synthesized ClosureType.
+ *
+ * ParameterReflection is the @api-stable interface; the concrete framework implementations
+ * (NativeParameterReflection et al.) are not covered by PHPStan's backward-compatibility promise,
+ * so we implement the interface directly to stay on supported surface.
+ */
+final readonly class ClosureParameter implements ParameterReflection
+{
+    public function __construct(private string $name, private Type $type) {}
+
+    #[Override]
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    #[Override]
+    public function isOptional(): bool
+    {
+        return false;
+    }
+
+    #[Override]
+    public function getType(): Type
+    {
+        return $this->type;
+    }
+
+    #[Override]
+    public function passedByReference(): PassedByReference
+    {
+        return PassedByReference::createNo();
+    }
+
+    #[Override]
+    public function isVariadic(): bool
+    {
+        return false;
+    }
+
+    #[Override]
+    public function getDefaultValue(): ?Type
+    {
+        return null;
+    }
+}

--- a/src/ParameterClosureTypes/RelationExistenceClosureBuilderParameterExtension.php
+++ b/src/ParameterClosureTypes/RelationExistenceClosureBuilderParameterExtension.php
@@ -1,0 +1,230 @@
+<?php declare(strict_types=1);
+
+namespace Hihaho\PhpstanRules\ParameterClosureTypes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Override;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\ClosureType;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\MethodParameterClosureTypeExtension;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+/**
+ * Infers the related-model builder type for the closure passed to Eloquent's relationship-existence
+ * query methods (whereHas, has, doesntHave, …) when the relation is given by name.
+ *
+ * Laravel 12 already types these callbacks as `Closure(Builder<TRelatedModel>): mixed` and binds
+ * `TRelatedModel` from the `Relation<TRelatedModel, …>|string $relation` parameter. But when the
+ * relation is passed as a string ('posts'), PHPStan cannot bind `TRelatedModel` from a string, so
+ * it falls back to the template bound — base `Model` — and the closure receives `Builder<Model>`.
+ * Under `checkModelProperties` that breaks every `->where(Model::SOME_COLUMN)` inside the closure:
+ * the column is checked against base `Model`, which has none, so it errors on valid columns.
+ *
+ * This extension resolves the concrete related model from the relation name via reflection and types
+ * the closure parameter as `Builder<TRelatedModel>`. PHPStan intersects this with any explicit hint
+ * the user wrote, so a bare `Builder $query` (an unparameterised `Builder`, a supertype of every
+ * `Builder<…>`) collapses to the related builder — no per-site annotation needed, arrow functions
+ * preserved. Dotted nested relations ('posts.comments' → Builder<Comment>) are walked segment by
+ * segment.
+ *
+ * Soundness: the extension only narrows when it can prove the related model from a single constant
+ * relation name and a resolvable relation method whose return type carries a concrete related model.
+ * In every other case it returns null and the default behaviour stands, so a genuinely wrong column
+ * on the correct related model still fails — this widens nothing.
+ */
+final readonly class RelationExistenceClosureBuilderParameterExtension implements MethodParameterClosureTypeExtension
+{
+    /**
+     * Relationship-existence methods on the Eloquent builder whose closure receives a builder scoped
+     * to the related model. Compared lowercased — PHP method names are case-insensitive.
+     */
+    private const array RELATION_METHODS = [
+        'has',
+        'orhas',
+        'doesnthave',
+        'ordoesnthave',
+        'wherehas',
+        'orwherehas',
+        'wheredoesnthave',
+        'orwheredoesnthave',
+    ];
+
+    public function __construct(private ReflectionProvider $reflectionProvider) {}
+
+    #[Override]
+    public function isMethodSupported(MethodReflection $methodReflection, ParameterReflection $parameter): bool
+    {
+        if ($parameter->getName() !== 'callback') {
+            return false;
+        }
+
+        if (! in_array(strtolower($methodReflection->getName()), self::RELATION_METHODS, true)) {
+            return false;
+        }
+
+        return $methodReflection->getDeclaringClass()->is(Builder::class);
+    }
+
+    #[Override]
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, ParameterReflection $parameter, Scope $scope): ?Type
+    {
+        $relationArgument = $this->findRelationArgument($methodCall);
+
+        if (! $relationArgument instanceof Expr) {
+            return null;
+        }
+
+        $relationNames = $scope->getType($relationArgument)->getConstantStrings();
+
+        if (count($relationNames) !== 1) {
+            return null;
+        }
+
+        $modelClass = $this->resolveReceiverModelClass($scope->getType($methodCall->var));
+
+        if ($modelClass === null) {
+            return null;
+        }
+
+        foreach (explode('.', $relationNames[0]->getValue()) as $relationName) {
+            $modelClass = $this->resolveRelatedModelClass($modelClass, $relationName, $scope);
+
+            if ($modelClass === null) {
+                return null;
+            }
+        }
+
+        return new ClosureType(
+            [new ClosureParameter('query', $this->resolveBuilderType($modelClass, $scope))],
+            new MixedType(),
+        );
+    }
+
+    /**
+     * Resolves the builder type the related model's queries actually use. A plain model yields
+     * `Builder<TRelatedModel>`; a model with a custom builder (Laravel's `HasBuilder` trait or an
+     * overridden `newEloquentBuilder()`) yields that custom builder, so relation-specific builder
+     * methods inside the closure keep resolving. Derived from the model's own `newQuery()` return
+     * type rather than hard-coded so both cases stay correct.
+     */
+    private function resolveBuilderType(string $modelClass, Scope $scope): Type
+    {
+        $modelType = new ObjectType($modelClass);
+
+        if ($modelType->hasMethod('newQuery')->yes()) {
+            $builderType = ParametersAcceptorSelector::selectFromArgs(
+                $scope,
+                [],
+                $modelType->getMethod('newQuery', $scope)->getVariants(),
+            )->getReturnType();
+
+            if ((new ObjectType(Builder::class))->isSuperTypeOf($builderType)->yes()) {
+                return $builderType;
+            }
+        }
+
+        return new GenericObjectType(Builder::class, [$modelType]);
+    }
+
+    /**
+     * Locates the `$relation` argument regardless of call style: by name when passed as a named
+     * argument (which may appear out of order, e.g. `whereHas(callback: …, relation: 'bars')`),
+     * otherwise the first positional argument — `$relation` is the first parameter of every method.
+     */
+    private function findRelationArgument(MethodCall $methodCall): ?Expr
+    {
+        $firstPositional = null;
+
+        foreach ($methodCall->getArgs() as $arg) {
+            if ($arg->name !== null) {
+                if ($arg->name->toString() === 'relation') {
+                    return $arg->value;
+                }
+
+                continue;
+            }
+
+            $firstPositional ??= $arg->value;
+        }
+
+        return $firstPositional;
+    }
+
+    /**
+     * Resolves the model the relation methods are scoped to. The receiver is normally a
+     * `Builder<TModel>`, but the methods are also reachable on a relation
+     * (`$user->posts()->whereHas(…)`), whose builder is scoped to the relation's related model.
+     */
+    private function resolveReceiverModelClass(Type $receiverType): ?string
+    {
+        return $this->resolveModelClass($receiverType->getTemplateType(Builder::class, 'TModel'))
+            ?? $this->resolveModelClass($receiverType->getTemplateType(Relation::class, 'TRelatedModel'));
+    }
+
+    private function resolveRelatedModelClass(string $modelClass, string $relationName, Scope $scope): ?string
+    {
+        if (! $this->reflectionProvider->hasClass($modelClass)) {
+            return null;
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($modelClass);
+
+        if (! $classReflection->hasMethod($relationName)) {
+            return null;
+        }
+
+        $relationType = ParametersAcceptorSelector::selectFromArgs(
+            $scope,
+            [],
+            $classReflection->getMethod($relationName, $scope)->getVariants(),
+        )->getReturnType();
+
+        if (! (new ObjectType(Relation::class))->isSuperTypeOf($relationType)->yes()) {
+            return null;
+        }
+
+        return $this->resolveModelClass(
+            $relationType->getTemplateType(Relation::class, 'TRelatedModel'),
+        );
+    }
+
+    /**
+     * Reduces a type to the single concrete Eloquent model class it refers to, or null when it is
+     * ambiguous, unknown, or merely the base Model (which carries no useful related-model info).
+     */
+    private function resolveModelClass(Type $type): ?string
+    {
+        $classNames = $type->getObjectClassNames();
+
+        if (count($classNames) !== 1) {
+            return null;
+        }
+
+        $className = $classNames[0];
+
+        if ($className === Model::class) {
+            return null;
+        }
+
+        if (! $this->reflectionProvider->hasClass($className)) {
+            return null;
+        }
+
+        if (! $this->reflectionProvider->getClass($className)->is(Model::class)) {
+            return null;
+        }
+
+        return $className;
+    }
+}

--- a/tests/ParameterClosureTypes/RelationExistenceClosureBuilderParameterExtensionTest.php
+++ b/tests/ParameterClosureTypes/RelationExistenceClosureBuilderParameterExtensionTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace Hihaho\PhpstanRules\Tests\ParameterClosureTypes;
+
+use Override;
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class RelationExistenceClosureBuilderParameterExtensionTest extends TypeInferenceTestCase
+{
+    /**
+     * @return iterable<mixed>
+     */
+    public static function dataFileAsserts(): iterable
+    {
+        yield from self::gatherAssertTypes(__DIR__ . '/stubs/RelationExistenceClosureTarget.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/stubs/RelationExistenceAliasTarget.php');
+    }
+
+    #[DataProvider('dataFileAsserts')]
+    public function testFileAsserts(string $assertType, string $file, mixed ...$args): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+
+    /**
+     * @return list<string>
+     */
+    #[Override]
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config.neon'];
+    }
+}

--- a/tests/ParameterClosureTypes/config.neon
+++ b/tests/ParameterClosureTypes/config.neon
@@ -1,0 +1,2 @@
+includes:
+    - ../../extension.neon

--- a/tests/ParameterClosureTypes/stubs/RelationExistenceAliasTarget.php
+++ b/tests/ParameterClosureTypes/stubs/RelationExistenceAliasTarget.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Hihaho\PhpstanRules\Tests\ParameterClosureTypes\stubs;
+
+use Illuminate\Database\Eloquent\Builder as EloquentQueryBuilder;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * humble-goat aliases `Illuminate\Database\Eloquent\Builder as EloquentQueryBuilder`. The alias is
+ * the same FQCN, so the extension narrows the closure parameter identically — proven here.
+ */
+final class RelationExistenceAliasTarget
+{
+    /**
+     * @param EloquentQueryBuilder<Foo> $query
+     */
+    public function exercise(EloquentQueryBuilder $query): void
+    {
+        $query->whereHas('bars', function (EloquentQueryBuilder $q): void {
+            assertType('Illuminate\Database\Eloquent\Builder<Hihaho\PhpstanRules\Tests\ParameterClosureTypes\stubs\Bar>', $q);
+        });
+    }
+}

--- a/tests/ParameterClosureTypes/stubs/RelationExistenceClosureTarget.php
+++ b/tests/ParameterClosureTypes/stubs/RelationExistenceClosureTarget.php
@@ -1,0 +1,122 @@
+<?php declare(strict_types=1);
+
+namespace Hihaho\PhpstanRules\Tests\ParameterClosureTypes\stubs;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\HasBuilder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+use function PHPStan\Testing\assertType;
+
+final class Foo extends Model
+{
+    /**
+     * @return HasMany<Bar, $this>
+     */
+    public function bars(): HasMany
+    {
+        return $this->hasMany(Bar::class);
+    }
+
+    /**
+     * @return HasMany<Qux, $this>
+     */
+    public function quxes(): HasMany
+    {
+        return $this->hasMany(Qux::class);
+    }
+}
+
+/**
+ * @extends Builder<Qux>
+ */
+final class QuxQueryBuilder extends Builder {}
+
+/**
+ * A related model with a custom Eloquent builder (Laravel's HasBuilder trait).
+ *
+ * @use HasBuilder<QuxQueryBuilder>
+ */
+final class Qux extends Model
+{
+    /** @use HasBuilder<QuxQueryBuilder> */
+    use HasBuilder;
+
+    protected static string $builder = QuxQueryBuilder::class;
+}
+
+final class Bar extends Model
+{
+    /**
+     * @return HasMany<Baz, $this>
+     */
+    public function bazzes(): HasMany
+    {
+        return $this->hasMany(Baz::class);
+    }
+}
+
+final class Baz extends Model {}
+
+/**
+ * @extends Builder<Foo>
+ */
+final class FooQueryBuilder extends Builder {}
+
+final class RelationExistenceClosureTarget
+{
+    /**
+     * @param Builder<Foo> $query
+     */
+    public function exercise(Builder $query, FooQueryBuilder $customQuery, Foo $foo): void
+    {
+        // Core case: a bare `Builder` hint on the closure is narrowed to the related model's builder.
+        $query->whereHas('bars', function (Builder $q): void {
+            assertType('Illuminate\Database\Eloquent\Builder<Hihaho\PhpstanRules\Tests\ParameterClosureTypes\stubs\Bar>', $q);
+        });
+
+        // Arrow functions are preserved and narrowed the same way.
+        $query->whereHas('bars', fn (Builder $q) => assertType('Illuminate\Database\Eloquent\Builder<Hihaho\PhpstanRules\Tests\ParameterClosureTypes\stubs\Bar>', $q));
+
+        // orWhereHas and whereDoesntHave use the same callback param.
+        $query->orWhereHas('bars', function (Builder $q): void {
+            assertType('Illuminate\Database\Eloquent\Builder<Hihaho\PhpstanRules\Tests\ParameterClosureTypes\stubs\Bar>', $q);
+        });
+        $query->whereDoesntHave('bars', function (Builder $q): void {
+            assertType('Illuminate\Database\Eloquent\Builder<Hihaho\PhpstanRules\Tests\ParameterClosureTypes\stubs\Bar>', $q);
+        });
+
+        // Dotted nested relations resolve segment by segment to the last related model.
+        $query->whereHas('bars.bazzes', function (Builder $q): void {
+            assertType('Illuminate\Database\Eloquent\Builder<Hihaho\PhpstanRules\Tests\ParameterClosureTypes\stubs\Baz>', $q);
+        });
+
+        // A custom builder subclass (extends Builder<Foo>) is narrowed the same way.
+        $customQuery->whereHas('bars', function (Builder $q): void {
+            assertType('Illuminate\Database\Eloquent\Builder<Hihaho\PhpstanRules\Tests\ParameterClosureTypes\stubs\Bar>', $q);
+        });
+
+        // Called on a relation ($foo->bars()): the receiver's related model (Bar) scopes the resolution.
+        $foo->bars()->whereHas('bazzes', function (Builder $q): void {
+            assertType('Illuminate\Database\Eloquent\Builder<Hihaho\PhpstanRules\Tests\ParameterClosureTypes\stubs\Baz>', $q);
+        });
+
+        // A related model with a custom builder keeps that builder type (not the base Builder),
+        // so relation-specific builder methods inside the closure still resolve.
+        $query->whereHas('quxes', function (Builder $q): void {
+            assertType(QuxQueryBuilder::class, $q);
+        });
+
+        // Named arguments, even out of order, resolve the relation by name (not by position).
+        $query->whereHas(relation: 'bars', callback: function (Builder $q): void {
+            assertType('Illuminate\Database\Eloquent\Builder<Hihaho\PhpstanRules\Tests\ParameterClosureTypes\stubs\Bar>', $q);
+        });
+
+        // Fail-safe: an unknown relation name is not narrowed — the default Builder<Model> stands,
+        // so nothing is widened and real errors elsewhere are preserved.
+        $query->whereHas('missing', function (Builder $q): void {
+            assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>', $q);
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Eloquent's relationship-existence query methods (`whereHas`, `has`, `doesntHave`, and their `or*`/`whereDoesntHave` variants) hand the closure a builder scoped to the *related* model. When the relation is passed as a string — the normal case — PHPStan can't bind the related model, so it falls back to `Builder<Model>`. Under `checkModelProperties` that makes every `->where(RelatedModel::SOME_COLUMN)` inside the closure fail on perfectly valid columns. This adds a type extension that infers the related model and types the closure as the related model's builder, so those false positives go away with no per-call-site annotation.

The closure needs no type hint change: a bare `Builder $q` is narrowed in place, and arrow functions are preserved.

## Coverage

- `whereHas`, `orWhereHas`, `whereDoesntHave`, `orWhereDoesntHave`, `has`, `orHas`, `doesntHave`, `orDoesntHave`.
- Dotted nested relations (`'posts.comments'`) resolve to the last related model.
- A related model with a custom builder (Laravel's `HasBuilder` / an overridden `newEloquentBuilder()`) keeps that builder type, so relation-specific builder methods inside the closure still resolve.
- Works when the methods are called on a builder, a custom builder subclass, or a relation (`$user->posts()->whereHas(...)`), and with named arguments.

It fails safe: when the model or relation can't be proven (dynamic relation name, unknown relation), the default typing stands — so a genuinely wrong column on the correct related model still fails. This narrows types; it never widens them.

## Testing

- `composer test` — 231 passing (11 new type-inference assertions covering each case above, including the fail-safe path).
- Style, static analysis, and the full suite are clean (`composer qa`).

To verify manually: in a project at PHPStan level 7+ with `checkModelProperties`, write `$query->whereHas('relation', fn (Builder $q) => $q->where(Related::SOME_COLUMN, ...))` and confirm the column no longer errors, while a misspelled column on the related model still does.

## Security & privacy

No security implications. Static-analysis-only; no runtime code path.

## Risk assessment

**Medium.** Two factors: it adds `illuminate/database` to `require` (the extension uses Eloquent symbols directly — previously only `illuminate/support` was required; every real Laravel consumer already has it), and it makes `whereHas`-closure types more specific, which can surface previously-hidden type errors in consumer code that relied on the looser `Builder<Model>`. Those surfaced errors are real, not regressions, but consumers may need to address them on upgrade.

## Known limitations

Covers relation-existence methods only. Same-model grouping closures (`where`/`when`/`tap`), the array form of `withCount`/`withSum`, and column-string methods like `whereRelation` are out of scope — the first is an outer-variable typing concern, and array-nested closures are never offered to a closure-type extension by PHPStan.
