### PR TITLE
Add route-model binding return type extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,42 @@ It is registered automatically — no configuration. Two guards keep it sound: d
 rather than guessed), and the receiver must be a `Support\Collection`/`LazyCollection` (or subclass)
 — a bare `Enumerable` or a custom implementation with unknown key semantics is never narrowed.
 
+### Route-model binding typing
+
+`RouteBindingReturnTypeExtension` types `$this->route('x')` / `$request->route('x')` as the model
+bound to route parameter `x`, reading the actual bindings from your route-service providers. Laravel
+types `route()` as `object|string|null`, so resolving a bound model normally needs an
+`assert($model instanceof Video)` after every call — and the parameter name doesn't reveal the model
+(`video_id` → `Video`). This reads `Route::model('x', M::class)` and `Route::bind('x', fn (): M => …)`
+from the configured providers and returns the bound type, so the assert is no longer needed while a
+wrong assignment still fails.
+
+Configure the providers to read via the `routeBindingProviders` parameter — it's empty by default, so
+nothing is narrowed until you list them:
+
+```neon
+parameters:
+    routeBindingProviders:
+        - App\Providers\RouteServiceProvider
+```
+
+```php
+public function handle(Request $request): void
+{
+    $video = $request->route('video_id'); // Video — no assert() needed
+}
+```
+
+Scope: only a single constant-string argument is narrowed (`route()` with no argument, a default
+argument, a dynamic name, or an unknown parameter keeps its default type); only the instance method
+is covered (the `Request::` facade's static form is out of scope); `Route::bind()` closures without a
+return-type hint, and `Route::model()` bindings with a missing-model callback, are skipped. A bound
+parameter is typed as the **non-null** model — matching the intent of the `assert()` calls it
+replaces. That over-claims by dropping `null` when the current route lacks the parameter (an optional
+`{param?}` segment, or shared middleware/helpers reached from routes without it), so use it for code
+reached only via routes that define the parameter and keep an explicit null check where a request may
+legitimately lack it.
+
 ## Parameter closure type extensions
 
 ### Relation-existence closure builder typing

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
             "tests/Rules/Debug/stubs/",
             "tests/Rules/Validation/stubs/",
             "tests/Rules/Conventions/stubs/",
-            "tests/ParameterClosureTypes/stubs/"
+            "tests/ParameterClosureTypes/stubs/",
+            "tests/ReturnTypes/stubs/routing/"
         ],
         "exclude-from-classmap": [
             "tests/Rules/stubs/facade-alias-in-view.blade.php"
@@ -38,6 +39,7 @@
         "php": "^8.3",
         "phpstan/phpstan": "^2.1.8",
         "illuminate/database": "^12.0||^13.0",
+        "illuminate/http": "^12.0||^13.0",
         "illuminate/support": "^12.0||^13.0"
     },
     "require-dev": {

--- a/extension.neon
+++ b/extension.neon
@@ -11,12 +11,17 @@ parametersSchema:
         firstPartyNamespaces: listOf(string())
     ])
     stubbedMethods: arrayOf(arrayOf(string()))
+    routeBindingProviders: listOf(string())
 
 parameters:
     # class name => (method name => return type string). Resolves runtime-only instance methods
     # (Faker providers, macros) so they need no baseline, while typos still fail.
     # Empty by default — each consuming project configures its own.
     stubbedMethods: []
+
+    # Provider class names whose source is parsed for Route::model()/Route::bind() bindings, used to
+    # type $this->route('x') as the bound model. Empty by default — each project lists its providers.
+    routeBindingProviders: []
 
     noUnsafeRequestData:
         unsafeMethods:
@@ -123,6 +128,14 @@ services:
             - phpstan.broker.methodsClassReflectionExtension
     -
         class: Hihaho\PhpstanRules\ReturnTypes\CollectionListAllReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+    -
+        class: Hihaho\PhpstanRules\ReturnTypes\RouteBindingReturnTypeExtension
+        arguments:
+            routeBindingProviders: %routeBindingProviders%
+            parser: @defaultAnalysisParser
+            reflectionProvider: @reflectionProvider
         tags:
             - phpstan.broker.dynamicMethodReturnTypeExtension
     -

--- a/src/ReturnTypes/RouteBindingReturnTypeExtension.php
+++ b/src/ReturnTypes/RouteBindingReturnTypeExtension.php
@@ -1,0 +1,242 @@
+<?php declare(strict_types=1);
+
+namespace Hihaho\PhpstanRules\ReturnTypes;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\NullableType;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\NodeFinder;
+use PHPStan\Analyser\Scope;
+use PHPStan\Parser\Parser;
+use PHPStan\Parser\ParserErrorsException;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+/**
+ * Types `$this->route('x')` / `$request->route('x')` (Illuminate\Http\Request::route()) as the model
+ * bound to route parameter `x` in the application's route-service providers.
+ *
+ * Laravel types `route()` as `object|string|null`, so every `$model = $request->route('video_id')`
+ * needs an `assert($model instanceof Video)` to recover the concrete type — and the parameter name
+ * does not reveal the model (`video_id` → Video, `container` → VideoContainer). This extension reads
+ * the actual bindings (`Route::model('x', M::class)` and `Route::bind('x', fn (): M => …)`) from the
+ * configured provider classes and returns the bound model type, so the assert becomes unnecessary
+ * while a wrong model assignment still fails.
+ *
+ * The binding map is parsed once from each provider's source — via the same name-resolving analysis
+ * parser the package's other reflection uses, so class names in the providers resolve to their FQCN —
+ * and memoized for the analysis run. It is configured per project through the `routeBindingProviders`
+ * parameter; with none configured it resolves nothing and the default `object|string|null` stands.
+ *
+ * Scope and soundness:
+ *  - Only a single constant-string argument is narrowed. `route()` with no argument (returns the Route
+ *    object), a dynamic name, or an unknown parameter is left at its default type.
+ *  - Only the instance method is covered (`$this->route()` / `$request->route()`); the `Request::`
+ *    facade's static form is out of scope.
+ *  - `Route::bind()` closures without a return-type hint, and `Route::model()` bindings that pass a
+ *    missing-model callback (whose result can replace the model), are skipped.
+ *  - Discovery is best-effort static parsing of the provider source: any `Route::model()`/`Route::bind()`
+ *    in the file declaring `boot()` is treated as registered, so a binding behind an environment guard
+ *    or in dead code is still picked up. Keep route bindings on the unconditional boot path.
+ *  - A bound parameter is typed as the non-null model — matching the intent of the `assert()` calls
+ *    it replaces, which also assumed the parameter was present. This over-claims by dropping `null`
+ *    whenever the current route does not carry the parameter — an optional `{param?}` segment, or
+ *    shared middleware/helpers reached from routes that lack it. That is an accepted tradeoff (the
+ *    feature exists to remove those asserts); apply it to code reached only via routes that define
+ *    the parameter, and keep an explicit null check where a request may legitimately lack it.
+ */
+final class RouteBindingReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    /**
+     * Lazily-built, memoized map of route-parameter name => bound model type. Null until built.
+     *
+     * @var array<string, Type>|null
+     */
+    private ?array $bindings = null;
+
+    /**
+     * @param  list<string>  $routeBindingProviders  Provider class names whose source is parsed for bindings.
+     */
+    public function __construct(
+        private readonly array $routeBindingProviders,
+        private readonly Parser $parser,
+        private readonly ReflectionProvider $reflectionProvider,
+    ) {}
+
+    #[Override]
+    public function getClass(): string
+    {
+        return Request::class;
+    }
+
+    #[Override]
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'route';
+    }
+
+    #[Override]
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
+    {
+        $args = $methodCall->getArgs();
+
+        // Narrow only the single-argument form. With a default (`route('x', $default)`) Laravel
+        // returns that default when the parameter is missing, so the bound model is not guaranteed.
+        if (! isset($args[0]) || isset($args[1])) {
+            return null;
+        }
+
+        $parameterNames = $scope->getType($args[0]->value)->getConstantStrings();
+
+        if (count($parameterNames) !== 1) {
+            return null;
+        }
+
+        return $this->bindings($scope)[$parameterNames[0]->getValue()] ?? null;
+    }
+
+    /**
+     * @return array<string, Type>
+     */
+    private function bindings(Scope $scope): array
+    {
+        if ($this->bindings !== null) {
+            return $this->bindings;
+        }
+
+        $bindings = [];
+
+        foreach ($this->routeBindingProviders as $provider) {
+            foreach ($this->bindingsFromProvider($provider, $scope) as $parameter => $type) {
+                $bindings[$parameter] = $type;
+            }
+        }
+
+        return $this->bindings = $bindings;
+    }
+
+    /**
+     * @return array<string, Type>
+     */
+    private function bindingsFromProvider(string $provider, Scope $scope): array
+    {
+        if (! $this->reflectionProvider->hasClass($provider)) {
+            return [];
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($provider);
+
+        // Bindings live in boot(), which may be inherited from a shared base provider — parse the
+        // file that actually declares it, not the configured subclass's file (which can be empty).
+        $declaringClass = $classReflection->hasMethod('boot')
+            ? $classReflection->getMethod('boot', $scope)->getDeclaringClass()
+            : $classReflection;
+
+        $file = $declaringClass->getFileName();
+
+        if ($file === null) {
+            return [];
+        }
+
+        try {
+            $statements = $this->parser->parseFile($file);
+        } catch (ParserErrorsException) {
+            return [];
+        }
+
+        $bindings = [];
+
+        foreach ((new NodeFinder())->findInstanceOf($statements, StaticCall::class) as $call) {
+            $binding = $this->bindingFromCall($call);
+
+            if ($binding === null) {
+                continue;
+            }
+
+            [$parameter, $type] = $binding;
+            $bindings[$parameter] = $type;
+        }
+
+        return $bindings;
+    }
+
+    /**
+     * @return array{string, Type}|null
+     */
+    private function bindingFromCall(StaticCall $call): ?array
+    {
+        if (! $call->class instanceof Name || $call->class->toString() !== Route::class) {
+            return null;
+        }
+
+        if (! $call->name instanceof Identifier) {
+            return null;
+        }
+
+        $args = $call->getArgs();
+        $parameterArgument = $args[0]->value ?? null;
+
+        if (! $parameterArgument instanceof String_) {
+            return null;
+        }
+
+        $type = match ($call->name->toLowerString()) {
+            // A third "missing model" callback can return something other than the model, so a
+            // binding that supplies one is skipped rather than narrowed unsoundly.
+            'model' => isset($args[2]) ? null : $this->modelBindingType($args[1]->value ?? null),
+            'bind' => $this->closureBindingType($args[1]->value ?? null),
+            default => null,
+        };
+
+        if (! $type instanceof Type) {
+            return null;
+        }
+
+        return [$parameterArgument->value, $type];
+    }
+
+    private function modelBindingType(?Node $argument): ?Type
+    {
+        if (! $argument instanceof ClassConstFetch || ! $argument->class instanceof Name) {
+            return null;
+        }
+
+        if (! $argument->name instanceof Identifier || $argument->name->toLowerString() !== 'class') {
+            return null;
+        }
+
+        return new ObjectType($argument->class->toString());
+    }
+
+    private function closureBindingType(?Node $argument): ?Type
+    {
+        if (! $argument instanceof Closure && ! $argument instanceof ArrowFunction) {
+            return null;
+        }
+
+        $returnType = $argument->getReturnType();
+
+        if ($returnType instanceof NullableType) {
+            $returnType = $returnType->type;
+        }
+
+        if (! $returnType instanceof Name) {
+            return null;
+        }
+
+        return new ObjectType($returnType->toString());
+    }
+}

--- a/src/ReturnTypes/RouteBindingReturnTypeExtension.php
+++ b/src/ReturnTypes/RouteBindingReturnTypeExtension.php
@@ -15,6 +15,7 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\UnionType;
 use PhpParser\NodeFinder;
 use PHPStan\Analyser\Scope;
 use PHPStan\Parser\Parser;
@@ -187,9 +188,9 @@ final class RouteBindingReturnTypeExtension implements DynamicMethodReturnTypeEx
         }
 
         $args = $call->getArgs();
-        $parameterArgument = $args[0]->value ?? null;
+        $parameterName = $this->parameterName($args[0]->value ?? null);
 
-        if (! $parameterArgument instanceof String_) {
+        if ($parameterName === null) {
             return null;
         }
 
@@ -205,7 +206,43 @@ final class RouteBindingReturnTypeExtension implements DynamicMethodReturnTypeEx
             return null;
         }
 
-        return [$parameterArgument->value, $type];
+        return [$parameterName, $type];
+    }
+
+    /**
+     * The route-parameter name from a binding's first argument: a string literal, or a class
+     * constant that resolves to a single string (`RouteParams::LOCALE`). `self::`/`static::` are not
+     * resolved — name resolution leaves them as special names with no reflectable class.
+     */
+    private function parameterName(?Node $argument): ?string
+    {
+        if ($argument instanceof String_) {
+            return $argument->value;
+        }
+
+        if (! $argument instanceof ClassConstFetch
+            || ! $argument->class instanceof Name
+            || ! $argument->name instanceof Identifier) {
+            return null;
+        }
+
+        $class = $argument->class->toString();
+
+        if (! $this->reflectionProvider->hasClass($class)) {
+            return null;
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($class);
+
+        if (! $classReflection->hasConstant($argument->name->toString())) {
+            return null;
+        }
+
+        // The value expression, not the value type — a typed constant (`const string X = 'x'`) types
+        // as `string`, so only the expression carries the literal name.
+        $valueExpr = $classReflection->getConstant($argument->name->toString())->getValueExpr();
+
+        return $valueExpr instanceof String_ ? $valueExpr->value : null;
     }
 
     private function modelBindingType(?Node $argument): ?Type
@@ -231,6 +268,12 @@ final class RouteBindingReturnTypeExtension implements DynamicMethodReturnTypeEx
 
         if ($returnType instanceof NullableType) {
             $returnType = $returnType->type;
+        }
+
+        // `T|null` carries the same information as `?T`; take the sole class member, if there is one.
+        if ($returnType instanceof UnionType) {
+            $names = array_values(array_filter($returnType->types, static fn (Node $type): bool => $type instanceof Name));
+            $returnType = count($names) === 1 ? $names[0] : null;
         }
 
         if (! $returnType instanceof Name) {

--- a/tests/ReturnTypes/RouteBindingReturnTypeExtensionTest.php
+++ b/tests/ReturnTypes/RouteBindingReturnTypeExtensionTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Hihaho\PhpstanRules\Tests\ReturnTypes;
+
+use Override;
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class RouteBindingReturnTypeExtensionTest extends TypeInferenceTestCase
+{
+    /**
+     * @return iterable<mixed>
+     */
+    public static function dataFileAsserts(): iterable
+    {
+        yield from self::gatherAssertTypes(__DIR__ . '/stubs/routing/RouteBindingTarget.php');
+    }
+
+    #[DataProvider('dataFileAsserts')]
+    public function testFileAsserts(string $assertType, string $file, mixed ...$args): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+
+    /**
+     * @return list<string>
+     */
+    #[Override]
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/route-binding-config.neon'];
+    }
+}

--- a/tests/ReturnTypes/route-binding-config.neon
+++ b/tests/ReturnTypes/route-binding-config.neon
@@ -1,0 +1,7 @@
+includes:
+    - ../../extension.neon
+
+parameters:
+    routeBindingProviders:
+        - Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\AppRouteServiceProvider
+        - Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\InheritingRouteServiceProvider

--- a/tests/ReturnTypes/stubs/routing/AppRouteServiceProvider.php
+++ b/tests/ReturnTypes/stubs/routing/AppRouteServiceProvider.php
@@ -11,6 +11,13 @@ final class Locale {}
 
 final class Playlist {}
 
+final class Subtitle {}
+
+final class RouteParams
+{
+    public const string SUBTITLE = 'subtitle';
+}
+
 final class AppRouteServiceProvider extends ServiceProvider
 {
     public function boot(): void
@@ -26,6 +33,12 @@ final class AppRouteServiceProvider extends ServiceProvider
 
         // Route::bind closure with a nullable return-type hint — narrowed to the non-null model.
         Route::bind('playlist', fn (string $value): ?Playlist => $value === '' ? null : new Playlist());
+
+        // Route::bind closure with a union return-type hint — narrowed to the sole class member.
+        Route::bind('union_playlist', fn (string $value): Playlist|null => $value === '' ? null : new Playlist());
+
+        // Route::model with a class-constant parameter name (RouteParams::SUBTITLE === 'subtitle').
+        Route::model(RouteParams::SUBTITLE, Subtitle::class);
 
         // Route::bind closure without a return-type hint — skipped (binding type unprovable).
         Route::bind('dynamic', fn (string $value) => $value);

--- a/tests/ReturnTypes/stubs/routing/AppRouteServiceProvider.php
+++ b/tests/ReturnTypes/stubs/routing/AppRouteServiceProvider.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing;
+
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\ServiceProvider;
+
+final class Video {}
+
+final class Locale {}
+
+final class Playlist {}
+
+final class AppRouteServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        // Route::model binding — second arg is a ::class constant.
+        Route::model('video', Video::class);
+
+        // Route::model with a missing-model callback — skipped (the callback can replace the model).
+        Route::model('guarded', Video::class, fn () => abort(404));
+
+        // Route::bind closure with an explicit return-type hint.
+        Route::bind('locale', fn (string $value): Locale => new Locale());
+
+        // Route::bind closure with a nullable return-type hint — narrowed to the non-null model.
+        Route::bind('playlist', fn (string $value): ?Playlist => $value === '' ? null : new Playlist());
+
+        // Route::bind closure without a return-type hint — skipped (binding type unprovable).
+        Route::bind('dynamic', fn (string $value) => $value);
+    }
+}

--- a/tests/ReturnTypes/stubs/routing/InheritedBootProvider.php
+++ b/tests/ReturnTypes/stubs/routing/InheritedBootProvider.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing;
+
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\ServiceProvider;
+
+abstract class BaseRouteServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        Route::model('inherited', Locale::class);
+    }
+}
+
+// Inherits boot() from the base — its own file declares no bindings. The extension must parse the
+// base file (where boot() is declared) to find them.
+final class InheritingRouteServiceProvider extends BaseRouteServiceProvider {}

--- a/tests/ReturnTypes/stubs/routing/RouteBindingTarget.php
+++ b/tests/ReturnTypes/stubs/routing/RouteBindingTarget.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
+
+use function PHPStan\Testing\assertType;
+
+final class RouteBindingTarget
+{
+    public function viaRequest(Request $request): void
+    {
+        // Route::model binding resolves to the bound model.
+        assertType(Video::class, $request->route('video'));
+
+        // Route::bind closure with a return-type hint resolves to that type.
+        assertType(Locale::class, $request->route('locale'));
+
+        // A nullable bind return type is narrowed to the non-null model.
+        assertType(Playlist::class, $request->route('playlist'));
+
+        // A bind without a return-type hint is not narrowed — default type stands.
+        assertType('object|string|null', $request->route('dynamic'));
+
+        // An unknown parameter is not narrowed.
+        assertType('object|string|null', $request->route('unknown'));
+
+        // With a default argument the bound model isn't guaranteed (Laravel returns the default when
+        // the parameter is missing), so it is not narrowed.
+        assertType('object|string|null', $request->route('video', 'fallback'));
+
+        // A Route::model binding with a missing-model callback is skipped (callback can replace it).
+        assertType('object|string|null', $request->route('guarded'));
+
+        // A binding declared in a provider's inherited boot() (in a base-class file) is found.
+        assertType(Locale::class, $request->route('inherited'));
+
+        // No argument returns the Route object — left untouched.
+        assertType(Route::class, $request->route());
+
+        // A dynamic (non-constant) parameter name is not narrowed.
+        $name = $this->name();
+        assertType('object|string|null', $request->route($name));
+    }
+
+    public function viaFormRequest(RouteBindingFormRequest $request): void
+    {
+        // The instance method on a FormRequest (a Request subclass) is narrowed too.
+        assertType(Video::class, $request->route('video'));
+    }
+
+    private function name(): string
+    {
+        return 'video';
+    }
+}
+
+final class RouteBindingFormRequest extends FormRequest {}

--- a/tests/ReturnTypes/stubs/routing/RouteBindingTarget.php
+++ b/tests/ReturnTypes/stubs/routing/RouteBindingTarget.php
@@ -37,6 +37,12 @@ final class RouteBindingTarget
         // A binding declared in a provider's inherited boot() (in a base-class file) is found.
         assertType(Locale::class, $request->route('inherited'));
 
+        // A bind with a `T|null` union return type is narrowed to the sole class member.
+        assertType(Playlist::class, $request->route('union_playlist'));
+
+        // A binding whose parameter name is a class constant (RouteParams::SUBTITLE) is resolved.
+        assertType(Subtitle::class, $request->route('subtitle'));
+
         // No argument returns the Route object — left untouched.
         assertType(Route::class, $request->route());
 


### PR DESCRIPTION
## Summary

Resolving a route-bound model from `$request->route('video_id')` normally needs an
`assert($model instanceof Video)` after every call, because Laravel types `route()` as
`object|string|null` and the parameter name doesn't reveal the model. This adds an opt-in type
extension that reads the application's actual route-model bindings and types `$this->route('x')` /
`$request->route('x')` as the bound model — so the assert is no longer needed while a wrong
assignment still fails.

It reads `Route::model('x', M::class)` and `Route::bind('x', fn (): M => …)` from the providers listed
in a new `routeBindingProviders` parameter. The parameter is empty by default, so the extension is a
no-op until a project configures it.

## Behaviour

- Narrows only a single constant-string argument. `route()` with no argument, a default argument
  (`route('x', $default)`), a dynamic name, or an unknown parameter keeps its default type.
- Only the instance method (`$this->route()` / `$request->route()`); the `Request::` facade's static
  form is out of scope.
- Skips `Route::bind()` closures without a return-type hint and `Route::model()` bindings with a
  missing-model callback (whose result can replace the model).
- Finds bindings even when `boot()` is inherited from a base provider (parses the declaring file).
- Types the bound parameter as the **non-null** model, matching the intent of the asserts it replaces.

## Testing

- `composer test` — 242 passing (11 new type-inference assertions: model binding, closure bind with
  return hint, nullable-hint unwrap, no-hint skip, missing-callback skip, default-arg, unknown param,
  no-arg `Route`, dynamic name, inherited `boot()`, and the FormRequest subclass path).
- Style, static analysis, and the full suite are clean (`composer qa`).

To verify manually: set `routeBindingProviders` to a provider that calls `Route::model('x', M::class)`,
then confirm `$request->route('x')` resolves to `M` with no assert, while an unknown parameter stays
`object|string|null`.

## Security & privacy

No security implications. Static-analysis-only; no runtime code path.

## Risk assessment

**Medium.** Opt-in (no effect until `routeBindingProviders` is set), but it adds `illuminate/http` to
`require` (the extension references `Request` directly; every Laravel consumer already has it) and,
once configured, types bound parameters as the non-null model. That over-claims by dropping `null`
when a request reaches the code via a route that lacks the parameter (an optional `{param?}` segment,
or shared middleware) — an accepted tradeoff that mirrors the asserts being removed, documented in the
README and class docblock.

## Known limitations

Discovery is best-effort static parsing of the provider source: a binding behind an environment guard
or in dead code is still treated as registered. Keep route bindings on the unconditional `boot()`
path. The non-null over-claim above is intentional; keep an explicit null check where a request may
legitimately lack the parameter.
