### PR TITLE
Fix route-binding extension under larastan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "illuminate/support": "^12.0||^13.0"
     },
     "require-dev": {
+        "larastan/larastan": "^3.0",
         "laravel/pao": "^1.1",
         "laravel/pint": "^1.21",
         "nikic/php-parser": "^5.4",
@@ -90,6 +91,11 @@
         "phpstan": {
             "includes": [
                 "extension.neon"
+            ]
+        },
+        "phpstan/extension-installer": {
+            "ignore": [
+                "larastan/larastan"
             ]
         }
     },

--- a/extension.neon
+++ b/extension.neon
@@ -134,10 +134,10 @@ services:
         class: Hihaho\PhpstanRules\ReturnTypes\RouteBindingReturnTypeExtension
         arguments:
             routeBindingProviders: %routeBindingProviders%
-            parser: @defaultAnalysisParser
+            parser: @currentPhpVersionSimpleDirectParser
             reflectionProvider: @reflectionProvider
         tags:
-            - phpstan.broker.dynamicMethodReturnTypeExtension
+            - phpstan.broker.expressionTypeResolverExtension
     -
         class: Hihaho\PhpstanRules\ParameterClosureTypes\RelationExistenceClosureBuilderParameterExtension
         arguments:

--- a/src/ReturnTypes/RouteBindingReturnTypeExtension.php
+++ b/src/ReturnTypes/RouteBindingReturnTypeExtension.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Override;
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\Closure;
@@ -17,12 +18,13 @@ use PhpParser\Node\NullableType;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\UnionType;
 use PhpParser\NodeFinder;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
 use PHPStan\Analyser\Scope;
 use PHPStan\Parser\Parser;
 use PHPStan\Parser\ParserErrorsException;
-use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ReflectionProvider;
-use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\ExpressionTypeResolverExtension;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 
@@ -37,10 +39,15 @@ use PHPStan\Type\Type;
  * configured provider classes and returns the bound model type, so the assert becomes unnecessary
  * while a wrong model assignment still fails.
  *
- * The binding map is parsed once from each provider's source — via the same name-resolving analysis
- * parser the package's other reflection uses, so class names in the providers resolve to their FQCN —
- * and memoized for the analysis run. It is configured per project through the `routeBindingProviders`
- * parameter; with none configured it resolves nothing and the default `object|string|null` stands.
+ * The binding map is parsed once from each provider's source — with the simple direct parser plus a
+ * name-resolution pass, so class names resolve to their FQCN — and memoized for the analysis run. It
+ * is configured per project through the `routeBindingProviders` parameter; with none configured it
+ * resolves nothing and the default `object|string|null` stands.
+ *
+ * This is an `ExpressionTypeResolverExtension`, not a `DynamicMethodReturnTypeExtension`, on purpose:
+ * PHPStan unions the results of all dynamic method-return extensions, and larastan ships one for
+ * `Request::route()` that returns a broad `object|string|null`, which would absorb the narrow model
+ * type. An expression-type resolver is consulted first and short-circuits, so the bound model wins.
  *
  * Scope and soundness:
  *  - Only a single constant-string argument is narrowed. `route()` with no argument (returns the Route
@@ -59,7 +66,7 @@ use PHPStan\Type\Type;
  *    feature exists to remove those asserts); apply it to code reached only via routes that define
  *    the parameter, and keep an explicit null check where a request may legitimately lack it.
  */
-final class RouteBindingReturnTypeExtension implements DynamicMethodReturnTypeExtension
+final class RouteBindingReturnTypeExtension implements ExpressionTypeResolverExtension
 {
     /**
      * Lazily-built, memoized map of route-parameter name => bound model type. Null until built.
@@ -78,25 +85,21 @@ final class RouteBindingReturnTypeExtension implements DynamicMethodReturnTypeEx
     ) {}
 
     #[Override]
-    public function getClass(): string
+    public function getType(Expr $expr, Scope $scope): ?Type
     {
-        return Request::class;
-    }
+        if (! $expr instanceof MethodCall || ! $expr->name instanceof Identifier || $expr->name->toLowerString() !== 'route') {
+            return null;
+        }
 
-    #[Override]
-    public function isMethodSupported(MethodReflection $methodReflection): bool
-    {
-        return $methodReflection->getName() === 'route';
-    }
-
-    #[Override]
-    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
-    {
-        $args = $methodCall->getArgs();
+        $args = $expr->getArgs();
 
         // Narrow only the single-argument form. With a default (`route('x', $default)`) Laravel
         // returns that default when the parameter is missing, so the bound model is not guaranteed.
         if (! isset($args[0]) || isset($args[1])) {
+            return null;
+        }
+
+        if (! (new ObjectType(Request::class))->isSuperTypeOf($scope->getType($expr->var))->yes()) {
             return null;
         }
 
@@ -157,6 +160,14 @@ final class RouteBindingReturnTypeExtension implements DynamicMethodReturnTypeEx
         } catch (ParserErrorsException) {
             return [];
         }
+
+        // Resolve names to their FQCN. The injected parser is the simple direct parser, which does
+        // not run name resolution itself — and crucially is not the default analysis parser, whose
+        // facade static calls are not reliably exposed once larastan is loaded.
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver());
+
+        $statements = $traverser->traverse($statements);
 
         $bindings = [];
 

--- a/tests/ReturnTypes/RouteBindingLarastanReturnTypeExtensionTest.php
+++ b/tests/ReturnTypes/RouteBindingLarastanReturnTypeExtensionTest.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Hihaho\PhpstanRules\Tests\ReturnTypes;
+
+use Override;
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Runs the route-binding extension with larastan loaded — the environment every real consumer uses,
+ * which the {@see RouteBindingReturnTypeExtensionTest} (Laravel-only) cannot cover.
+ */
+final class RouteBindingLarastanReturnTypeExtensionTest extends TypeInferenceTestCase
+{
+    /**
+     * @return iterable<mixed>
+     */
+    public static function dataFileAsserts(): iterable
+    {
+        yield from self::gatherAssertTypes(__DIR__ . '/stubs/routing/RouteBindingLarastanTarget.php');
+    }
+
+    #[DataProvider('dataFileAsserts')]
+    public function testFileAsserts(string $assertType, string $file, mixed ...$args): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+
+    /**
+     * @return list<string>
+     */
+    #[Override]
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/route-binding-larastan-config.neon'];
+    }
+}

--- a/tests/ReturnTypes/route-binding-larastan-config.neon
+++ b/tests/ReturnTypes/route-binding-larastan-config.neon
@@ -1,0 +1,8 @@
+includes:
+    - ../../vendor/larastan/larastan/extension.neon
+    - ../../extension.neon
+
+parameters:
+    routeBindingProviders:
+        - Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\AppRouteServiceProvider
+        - Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\InheritingRouteServiceProvider

--- a/tests/ReturnTypes/stubs/routing/RouteBindingLarastanTarget.php
+++ b/tests/ReturnTypes/stubs/routing/RouteBindingLarastanTarget.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing;
+
+use Illuminate\Http\Request;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * Regression guard for the larastan environment. larastan ships its own broad `Request::route()`
+ * return-type extension (`object|string|null`) and changes how facade calls surface from the default
+ * analysis parser. This asserts the bound model still wins under larastan — the env every real
+ * consumer runs, and the one the package's other tests don't exercise.
+ */
+final class RouteBindingLarastanTarget
+{
+    public function exercise(Request $request): void
+    {
+        assertType(Video::class, $request->route('video'));
+        assertType(Locale::class, $request->route('locale'));
+        assertType(Subtitle::class, $request->route('subtitle'));
+
+        // Inherited boot() binding, resolved under larastan too.
+        assertType(Locale::class, $request->route('inherited'));
+    }
+}


### PR DESCRIPTION
## Summary

v3.11.0's `RouteBindingReturnTypeExtension` found **zero** bindings in any larastan-enabled app — i.e. every real Laravel project — silently leaving `$request->route('x')` as `object|string|null`. Surfaced at integration; the package's own test suite missed it because it had no larastan installed (a false-confidence gap). This fixes both root causes and adds a larastan-exercised regression test.

## Root causes

1. **larastan's `Request::route()` extension wins the union.** larastan ships its own `DynamicMethodReturnTypeExtension` for `route()` returning a broad `object|string|null`. PHPStan **unions** the results of all dynamic method-return extensions, so that broad type absorbed our narrow bound model. Switched to an `ExpressionTypeResolverExtension`, which `resolveType()` consults *first* and short-circuits — so the bound model wins.
2. **The default analysis parser doesn't reliably expose facade static calls under larastan.** Switched provider parsing to the simple direct parser (`@currentPhpVersionSimpleDirectParser`) plus an explicit `NameResolver` pass (the combination larastan itself uses for source introspection).

## Why it wasn't caught

The package had no larastan in dev deps, so the default parser kept `Route::` as a `StaticCall` and no competing `route()` extension existed — tests passed against an environment the package never actually ships into.

## Changes

- Extension reimplemented as `ExpressionTypeResolverExtension`; provider parsing via the simple direct parser + `NameResolver`. Behavior, scope, and all skip/edge rules are unchanged.
- Added `larastan/larastan` as a dev dependency and a **regression test that runs with larastan loaded** (`RouteBindingLarastanReturnTypeExtensionTest`), asserting bindings still narrow.
- Excluded larastan from the package's own analysis via the extension-installer `ignore` list — it's only needed by the regression test's config, not the package's self-analysis.

## Testing

- `composer test` — 248 passing / 325 assertions, including 4 new assertions exercised **with larastan loaded** (the env that exposed the bug) plus the existing 13 Laravel-only edge-case assertions.
- Style, static analysis, and the full suite are clean (`composer qa`).

## Security & privacy

No security implications. Static-analysis-only.

## Risk assessment

**Medium.** Patch fixing a non-functional feature. Adds a dev-only dependency (`larastan`) and changes the extension's registration mechanism, but the observable behavior and public config (`routeBindingProviders`) are identical — verified by the unchanged Laravel-only test plus the new larastan regression test.
