### PR TITLE
Add adoption notes and broaden extension fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,13 @@ replaces. That over-claims by dropping `null` when the current route lacks the p
 reached only via routes that define the parameter and keep an explicit null check where a request may
 legitimately lack it.
 
+> **Adopting this is a one-time assert-removal sweep.** Once `route('x')` is typed as the bound
+> model, any existing `assert($x instanceof Model)` or `instanceof` guard after it becomes
+> "always true" — PHPStan reports it as a redundant condition. (This is an expression-type resolver,
+> so `treatPhpDocTypesAsCertain: false` does not soften it.) Removing those now-redundant asserts is
+> the point of the feature; expect a one-off cleanup when you first enable `routeBindingProviders`.
+> Keep only the guards on routes that may legitimately lack the parameter (the non-null caveat above).
+
 ## Parameter closure type extensions
 
 ### Relation-existence closure builder typing
@@ -353,6 +360,23 @@ It is registered automatically — no configuration. The closure parameter needs
 (`HasBuilder`/`newEloquentBuilder()`) keeps that builder type. It fails safe: when the model or
 relation can't be proven (dynamic relation name, unknown relation), the default typing stands, so a
 genuinely wrong column on the correct related model still fails.
+
+> **Use `void` closures, not closures that return the builder.** Eloquent's `Builder<TModel>` is
+> invariant, and Laravel types the callback's return as `mixed` (it's ignored at runtime — the
+> closure constrains the query in place). Once the parameter is narrowed to the related model, a
+> closure that *returns* the builder — e.g. `fn ($q) => $q->where(...)` or `return $q->where(...)` —
+> reports `return.type: should return Builder<Model> but returns Builder<RelatedModel>`. Write the
+> callback as a `void` block instead; the return value serves no purpose:
+>
+> ```php
+> // Triggers a return.type error (returns the narrowed builder):
+> $query->whereHas('posts', fn (Builder $q) => $q->where(Post::STATUS, Post::PUBLISHED));
+>
+> // Clean — the closure constrains in place and returns nothing:
+> $query->whereHas('posts', function (Builder $q): void {
+>     $q->where(Post::STATUS, Post::PUBLISHED);
+> });
+> ```
 
 ## Testing
 

--- a/tests/ParameterClosureTypes/stubs/RelationExistenceClosureTarget.php
+++ b/tests/ParameterClosureTypes/stubs/RelationExistenceClosureTarget.php
@@ -79,11 +79,21 @@ final class RelationExistenceClosureTarget
         // Arrow functions are preserved and narrowed the same way.
         $query->whereHas('bars', fn (Builder $q) => assertType('Illuminate\Database\Eloquent\Builder<Hihaho\PhpstanRules\Tests\ParameterClosureTypes\stubs\Bar>', $q));
 
-        // orWhereHas and whereDoesntHave use the same callback param.
+        // The whole relationship-existence family shares the same callback param. `doesntHave` and
+        // `has` take the callback in a later position (after $boolean/$operator) — resolved by name.
         $query->orWhereHas('bars', function (Builder $q): void {
             assertType('Illuminate\Database\Eloquent\Builder<Hihaho\PhpstanRules\Tests\ParameterClosureTypes\stubs\Bar>', $q);
         });
         $query->whereDoesntHave('bars', function (Builder $q): void {
+            assertType('Illuminate\Database\Eloquent\Builder<Hihaho\PhpstanRules\Tests\ParameterClosureTypes\stubs\Bar>', $q);
+        });
+        $query->orWhereDoesntHave('bars', function (Builder $q): void {
+            assertType('Illuminate\Database\Eloquent\Builder<Hihaho\PhpstanRules\Tests\ParameterClosureTypes\stubs\Bar>', $q);
+        });
+        $query->doesntHave('bars', 'and', function (Builder $q): void {
+            assertType('Illuminate\Database\Eloquent\Builder<Hihaho\PhpstanRules\Tests\ParameterClosureTypes\stubs\Bar>', $q);
+        });
+        $query->has('bars', '>=', 1, 'and', function (Builder $q): void {
             assertType('Illuminate\Database\Eloquent\Builder<Hihaho\PhpstanRules\Tests\ParameterClosureTypes\stubs\Bar>', $q);
         });
 

--- a/tests/ReturnTypes/stubs/routing/AppRouteServiceProvider.php
+++ b/tests/ReturnTypes/stubs/routing/AppRouteServiceProvider.php
@@ -40,6 +40,9 @@ final class AppRouteServiceProvider extends ServiceProvider
         // Route::model with a class-constant parameter name (RouteParams::SUBTITLE === 'subtitle').
         Route::model(RouteParams::SUBTITLE, Subtitle::class);
 
+        // Route::bind closure with a built-in (non-class) return type — skipped (not a bound model).
+        Route::bind('idp_name', fn (string $value): string => $value);
+
         // Route::bind closure without a return-type hint — skipped (binding type unprovable).
         Route::bind('dynamic', fn (string $value) => $value);
     }

--- a/tests/ReturnTypes/stubs/routing/RouteBindingTarget.php
+++ b/tests/ReturnTypes/stubs/routing/RouteBindingTarget.php
@@ -24,6 +24,9 @@ final class RouteBindingTarget
         // A bind without a return-type hint is not narrowed — default type stands.
         assertType('object|string|null', $request->route('dynamic'));
 
+        // A bind whose closure returns a built-in type (not a class) is not narrowed.
+        assertType('object|string|null', $request->route('idp_name'));
+
         // An unknown parameter is not narrowed.
         assertType('object|string|null', $request->route('unknown'));
 


### PR DESCRIPTION
## Summary

Two README adoption notes, both surfaced by real consumer integration (humble-goat and the hihaho app), plus broader test fixtures. No behavior or public-API change.

## Docs

- **`whereHas` / relation closures** — returning the narrowed builder (`fn ($q) => $q->where(...)`) trips a `return.type` covariance error because `Builder<TModel>` is invariant. Documented: use `void` block closures (the return value is ignored at runtime anyway).
- **`routeBindingProviders`** — once `route('x')` is typed as the bound model, existing `assert($x instanceof Model)` / `instanceof` guards after it become "always true" (redundant-condition errors). It's an expression-type resolver, so `treatPhpDocTypesAsCertain: false` doesn't soften it. Documented that adopting is a one-time assert-removal sweep, keeping only the guards on routes that may legitimately lack the parameter.

## Fixtures

- Relation extension: exercise the full relationship-existence family — `orWhereDoesntHave`, `doesntHave` (callback after `$boolean`), and `has` (callback after `$operator`/`$count`/`$boolean`) — not just `whereHas`/`whereDoesntHave`.
- Route-binding extension: a `Route::bind()` closure with a built-in return type (`: string`, e.g. a Socialite/SAML `idpName` bind) is skipped, not narrowed.

## Testing

- `composer test` — 252 passing / 329 assertions (4 new relation-family assertions + 1 route-binding skip case). Style, static analysis, and the full suite are clean.

## Security & privacy

No security implications. Docs + test fixtures only.

## Risk assessment

**Low.** Documentation and test-only; no `src/` behavior change.
