### PR TITLE
Add implicit route-model binding resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,25 @@ replaces. That over-claims by dropping `null` when the current route lacks the p
 reached only via routes that define the parameter and keep an explicit null check where a request may
 legitimately lack it.
 
+**Implicit bindings.** Parameters bound implicitly (by the controller's type-hint, with no
+`Route::model()` declaration) are resolved as a fallback by listing your route files in `routeFiles`:
+
+```neon
+parameters:
+    routeFiles:
+        - routes/web.php
+        - routes/api.php
+```
+
+It reads each `Route::<verb>('uri/{param}', Action)` — an invokable `Controller::class` or a
+`[Controller::class, 'method']` — and types `route('param')` as the action parameter Laravel would
+bind to it (matched by name or `Str::snake()`, exactly as the framework does), unioned across every
+route that declares the parameter. Explicit provider bindings win over implicit ones. It is fail-safe:
+closures, group-level controllers, `Route::resource`, non-model type-hints, and unreadable files are
+skipped, leaving the default type — it never mis-types. Paths are resolved from the working directory
+PHPStan runs in (your project root), so project-relative paths like `routes/web.php` work; the
+extension parses the files statically — it does not boot your application.
+
 > **Adopting this is a one-time assert-removal sweep.** Once `route('x')` is typed as the bound
 > model, any existing `assert($x instanceof Model)` or `instanceof` guard after it becomes
 > "always true" — PHPStan reports it as a redundant condition. (This is an expression-type resolver,

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
             "tests/Rules/Validation/stubs/",
             "tests/Rules/Conventions/stubs/",
             "tests/ParameterClosureTypes/stubs/",
-            "tests/ReturnTypes/stubs/routing/"
+            "tests/ReturnTypes/stubs/routing/",
+            "tests/ReturnTypes/stubs/routing/implicit/"
         ],
         "exclude-from-classmap": [
             "tests/Rules/stubs/facade-alias-in-view.blade.php"

--- a/extension.neon
+++ b/extension.neon
@@ -12,6 +12,7 @@ parametersSchema:
     ])
     stubbedMethods: arrayOf(arrayOf(string()))
     routeBindingProviders: listOf(string())
+    routeFiles: listOf(string())
 
 parameters:
     # class name => (method name => return type string). Resolves runtime-only instance methods
@@ -22,6 +23,10 @@ parameters:
     # Provider class names whose source is parsed for Route::model()/Route::bind() bindings, used to
     # type $this->route('x') as the bound model. Empty by default — each project lists its providers.
     routeBindingProviders: []
+
+    # Route file paths parsed for implicit (controller type-hint) route-model bindings, used as the
+    # fallback for $this->route('x') when 'x' is not declared in a provider. Empty by default.
+    routeFiles: []
 
     noUnsafeRequestData:
         unsafeMethods:
@@ -131,11 +136,18 @@ services:
         tags:
             - phpstan.broker.dynamicMethodReturnTypeExtension
     -
+        class: Hihaho\PhpstanRules\ReturnTypes\ImplicitRouteBindingResolver
+        arguments:
+            routeFiles: %routeFiles%
+            parser: @currentPhpVersionSimpleDirectParser
+            reflectionProvider: @reflectionProvider
+    -
         class: Hihaho\PhpstanRules\ReturnTypes\RouteBindingReturnTypeExtension
         arguments:
             routeBindingProviders: %routeBindingProviders%
             parser: @currentPhpVersionSimpleDirectParser
             reflectionProvider: @reflectionProvider
+            implicitResolver: @Hihaho\PhpstanRules\ReturnTypes\ImplicitRouteBindingResolver
         tags:
             - phpstan.broker.expressionTypeResolverExtension
     -

--- a/rector.php
+++ b/rector.php
@@ -21,6 +21,8 @@ return RectorConfig::configure()
         __DIR__ . '/tests/Rules/stubs',
         __DIR__ . '/tests/Rules/Debug/stubs',
         __DIR__ . '/tests/Rules/Conventions/stubs',
+        __DIR__ . '/tests/ReturnTypes/stubs',
+        __DIR__ . '/tests/ParameterClosureTypes/stubs',
         AddArrowFunctionReturnTypeRector::class,
         EncapsedStringsToSprintfRector::class,
         ExplicitBoolCompareRector::class,

--- a/src/ReturnTypes/ImplicitRouteBindingResolver.php
+++ b/src/ReturnTypes/ImplicitRouteBindingResolver.php
@@ -1,0 +1,234 @@
+<?php declare(strict_types=1);
+
+namespace Hihaho\PhpstanRules\ReturnTypes;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\NodeFinder;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PHPStan\Analyser\Scope;
+use PHPStan\Parser\Parser;
+use PHPStan\Parser\ParserErrorsException;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+/**
+ * Resolves Laravel implicit route-model bindings to the bound model type, by statically reading the
+ * application's route files — no `route:list` manifest, no runtime boot.
+ *
+ * Laravel's `ImplicitRouteBinding` derives the model from the controller method's type-hint, matching
+ * the route parameter to the method parameter by name or `Str::snake()` of it. This mirrors that 1:1:
+ * for each `Route::<verb>('uri/{param}', Action)` in a configured route file, it resolves the action's
+ * method, finds the parameter Laravel would bind to each route parameter, and keeps its type when it
+ * is a Model. `route('param')` is then the union of those models across every route that declares it
+ * (a call site can run under multiple routes, so the union is the sound static type).
+ *
+ * Best-effort and fail-safe: only `Route::<verb>(string, Action)` calls with a `Controller::class`
+ * (invokable `__invoke`) or `[Controller::class, 'method']` action are read. Anything else — a closure
+ * or string action, a group-level controller, `Route::resource`, a non-model or un-hinted parameter —
+ * is skipped, leaving the default type. It never mis-types; it only narrows what it can prove.
+ */
+final class ImplicitRouteBindingResolver
+{
+    private const array ROUTE_VERBS = ['get', 'post', 'put', 'patch', 'delete', 'options', 'any', 'match'];
+
+    /**
+     * Lazily-built, memoized map of route-parameter name => bound model type. Null until built.
+     *
+     * @var array<string, Type>|null
+     */
+    private ?array $bindings = null;
+
+    /**
+     * @param  list<string>  $routeFiles  Route file paths parsed for implicit (type-hint) bindings.
+     */
+    public function __construct(
+        private readonly array $routeFiles,
+        private readonly Parser $parser,
+        private readonly ReflectionProvider $reflectionProvider,
+    ) {}
+
+    /**
+     * @return array<string, Type>
+     */
+    public function bindings(Scope $scope): array
+    {
+        if ($this->bindings !== null) {
+            return $this->bindings;
+        }
+
+        /** @var array<string, list<Type>> $collected */
+        $collected = [];
+
+        foreach ($this->routeFiles as $routeFile) {
+            foreach ($this->routeCalls($routeFile) as $call) {
+                $this->collectFromCall($call, $scope, $collected);
+            }
+        }
+
+        $bindings = [];
+
+        foreach ($collected as $parameter => $types) {
+            $bindings[$parameter] = TypeCombinator::union(...$types);
+        }
+
+        return $this->bindings = $bindings;
+    }
+
+    /**
+     * @return list<StaticCall>
+     */
+    private function routeCalls(string $routeFile): array
+    {
+        // A misconfigured or unreadable route-file path must not break analysis — fail safe.
+        if (! is_file($routeFile) || ! is_readable($routeFile)) {
+            return [];
+        }
+
+        try {
+            $statements = $this->parser->parseFile($routeFile);
+        } catch (ParserErrorsException) {
+            return [];
+        }
+
+        // Simple direct parser does not resolve names, and is not the default analysis parser whose
+        // facade static calls are unreliable under larastan — resolve names ourselves.
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver());
+
+        $statements = $traverser->traverse($statements);
+
+        return array_values((new NodeFinder())->findInstanceOf($statements, StaticCall::class));
+    }
+
+    /**
+     * @param  array<string, list<Type>>  $collected
+     */
+    private function collectFromCall(StaticCall $call, Scope $scope, array &$collected): void
+    {
+        if (! $call->class instanceof Name || $call->class->toString() !== Route::class || ! $call->name instanceof Identifier) {
+            return;
+        }
+
+        if (! in_array($call->name->toLowerString(), self::ROUTE_VERBS, true)) {
+            return;
+        }
+
+        $args = $call->getArgs();
+
+        // `match($methods, $uri, $action)` shifts the uri/action by one; every other verb is ($uri, $action).
+        $offset = $call->name->toLowerString() === 'match' ? 1 : 0;
+        $uri = $args[$offset]->value ?? null;
+        $action = $args[$offset + 1]->value ?? null;
+
+        if (! $uri instanceof String_ || $action === null) {
+            return;
+        }
+
+        $method = $this->resolveActionMethod($action);
+
+        if ($method === null) {
+            return;
+        }
+
+        foreach ($this->routeParameters($uri->value) as $parameter) {
+            $type = $this->boundModelType($method, $parameter, $scope);
+
+            if ($type instanceof Type) {
+                $collected[$parameter][] = $type;
+            }
+        }
+    }
+
+    /**
+     * The action's [class, method]: a `Controller::class` is invokable (`__invoke`); a
+     * `[Controller::class, 'method']` names the method. Closures and string actions are skipped.
+     *
+     * @return array{string, string}|null
+     */
+    private function resolveActionMethod(Node $action): ?array
+    {
+        if ($action instanceof ClassConstFetch) {
+            return $action->class instanceof Name ? [$action->class->toString(), '__invoke'] : null;
+        }
+
+        if (! $action instanceof Array_ || count($action->items) !== 2) {
+            return null;
+        }
+
+        $class = $action->items[0]->value;
+        $method = $action->items[1]->value;
+
+        if (! $class instanceof ClassConstFetch || ! $class->class instanceof Name || ! $method instanceof String_) {
+            return null;
+        }
+
+        return [$class->class->toString(), $method->value];
+    }
+
+    /**
+     * Route parameter names from a URI, dropping the optional marker and any binding field
+     * (`{video}`, `{video?}`, `{video:slug}` all yield `video`).
+     *
+     * @return list<string>
+     */
+    private function routeParameters(string $uri): array
+    {
+        if (preg_match_all('/\{(\w+)/', $uri, $matches) === false) {
+            return [];
+        }
+
+        return $matches[1];
+    }
+
+    /**
+     * The bound model type for a route parameter: the type of the action-method parameter Laravel
+     * would match to it (exact name, or `Str::snake()` of the method parameter name), when a Model.
+     *
+     * @param  array{string, string}  $method
+     */
+    private function boundModelType(array $method, string $routeParameter, Scope $scope): ?Type
+    {
+        [$class, $methodName] = $method;
+
+        if (! $this->reflectionProvider->hasClass($class)) {
+            return null;
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($class);
+
+        if (! $classReflection->hasMethod($methodName)) {
+            return null;
+        }
+
+        $parameters = ParametersAcceptorSelector::selectFromArgs(
+            $scope,
+            [],
+            $classReflection->getMethod($methodName, $scope)->getVariants(),
+        )->getParameters();
+
+        foreach ($parameters as $parameter) {
+            if ($parameter->getName() !== $routeParameter && Str::snake($parameter->getName()) !== $routeParameter) {
+                continue;
+            }
+
+            return (new ObjectType(Model::class))->isSuperTypeOf($parameter->getType())->yes()
+                ? $parameter->getType()
+                : null;
+        }
+
+        return null;
+    }
+}

--- a/src/ReturnTypes/RouteBindingReturnTypeExtension.php
+++ b/src/ReturnTypes/RouteBindingReturnTypeExtension.php
@@ -44,6 +44,9 @@ use PHPStan\Type\Type;
  * is configured per project through the `routeBindingProviders` parameter; with none configured it
  * resolves nothing and the default `object|string|null` stands.
  *
+ * Parameters not declared in a provider fall through to {@see ImplicitRouteBindingResolver}, which
+ * resolves Laravel's implicit (controller type-hint) bindings from the configured `routeFiles`.
+ *
  * This is an `ExpressionTypeResolverExtension`, not a `DynamicMethodReturnTypeExtension`, on purpose:
  * PHPStan unions the results of all dynamic method-return extensions, and larastan ships one for
  * `Request::route()` that returns a broad `object|string|null`, which would absorb the narrow model
@@ -82,6 +85,7 @@ final class RouteBindingReturnTypeExtension implements ExpressionTypeResolverExt
         private readonly array $routeBindingProviders,
         private readonly Parser $parser,
         private readonly ReflectionProvider $reflectionProvider,
+        private readonly ImplicitRouteBindingResolver $implicitResolver,
     ) {}
 
     #[Override]
@@ -109,7 +113,13 @@ final class RouteBindingReturnTypeExtension implements ExpressionTypeResolverExt
             return null;
         }
 
-        return $this->bindings($scope)[$parameterNames[0]->getValue()] ?? null;
+        $parameter = $parameterNames[0]->getValue();
+
+        // Explicit Route::model()/Route::bind() bindings win; implicit (controller type-hint) bindings
+        // are the fallback for parameters not declared in a provider.
+        return $this->bindings($scope)[$parameter]
+            ?? $this->implicitResolver->bindings($scope)[$parameter]
+            ?? null;
     }
 
     /**

--- a/tests/ReturnTypes/ImplicitRouteBindingPrecedenceTest.php
+++ b/tests/ReturnTypes/ImplicitRouteBindingPrecedenceTest.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Hihaho\PhpstanRules\Tests\ReturnTypes;
+
+use Override;
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Explicit Route::model()/Route::bind() bindings take precedence over implicit (controller type-hint)
+ * bindings for the same route parameter.
+ */
+final class ImplicitRouteBindingPrecedenceTest extends TypeInferenceTestCase
+{
+    /**
+     * @return iterable<mixed>
+     */
+    public static function dataFileAsserts(): iterable
+    {
+        yield from self::gatherAssertTypes(__DIR__ . '/stubs/routing/implicit/PrecedenceTarget.php');
+    }
+
+    #[DataProvider('dataFileAsserts')]
+    public function testFileAsserts(string $assertType, string $file, mixed ...$args): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+
+    /**
+     * @return list<string>
+     */
+    #[Override]
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/route-binding-precedence-config.neon'];
+    }
+}

--- a/tests/ReturnTypes/ImplicitRouteBindingReturnTypeExtensionTest.php
+++ b/tests/ReturnTypes/ImplicitRouteBindingReturnTypeExtensionTest.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Hihaho\PhpstanRules\Tests\ReturnTypes;
+
+use Override;
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Implicit (controller type-hint) route-model binding resolution, run with larastan loaded — the
+ * environment every real consumer uses.
+ */
+final class ImplicitRouteBindingReturnTypeExtensionTest extends TypeInferenceTestCase
+{
+    /**
+     * @return iterable<mixed>
+     */
+    public static function dataFileAsserts(): iterable
+    {
+        yield from self::gatherAssertTypes(__DIR__ . '/stubs/routing/implicit/ImplicitRouteBindingTarget.php');
+    }
+
+    #[DataProvider('dataFileAsserts')]
+    public function testFileAsserts(string $assertType, string $file, mixed ...$args): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+
+    /**
+     * @return list<string>
+     */
+    #[Override]
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/route-binding-implicit-config.neon'];
+    }
+}

--- a/tests/ReturnTypes/ImplicitRouteBindingStaticTest.php
+++ b/tests/ReturnTypes/ImplicitRouteBindingStaticTest.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Hihaho\PhpstanRules\Tests\ReturnTypes;
+
+use Override;
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Implicit route-model binding resolution without larastan — the skip cases assert a stable default
+ * route() type, which the larastan-loaded {@see ImplicitRouteBindingReturnTypeExtensionTest} can't.
+ */
+final class ImplicitRouteBindingStaticTest extends TypeInferenceTestCase
+{
+    /**
+     * @return iterable<mixed>
+     */
+    public static function dataFileAsserts(): iterable
+    {
+        yield from self::gatherAssertTypes(__DIR__ . '/stubs/routing/implicit/ImplicitRouteBindingStaticTarget.php');
+    }
+
+    #[DataProvider('dataFileAsserts')]
+    public function testFileAsserts(string $assertType, string $file, mixed ...$args): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+
+    /**
+     * @return list<string>
+     */
+    #[Override]
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/route-binding-implicit-static-config.neon'];
+    }
+}

--- a/tests/ReturnTypes/route-binding-implicit-config.neon
+++ b/tests/ReturnTypes/route-binding-implicit-config.neon
@@ -1,0 +1,9 @@
+includes:
+    - ../../vendor/larastan/larastan/extension.neon
+    - ../../extension.neon
+
+parameters:
+    # Plain relative path — resolved against the process working directory (the package root when the
+    # test suite runs). Real consumers point this at their own route files, e.g. routes/web.php.
+    routeFiles:
+        - tests/ReturnTypes/stubs/routing/implicit/routes.php

--- a/tests/ReturnTypes/route-binding-implicit-static-config.neon
+++ b/tests/ReturnTypes/route-binding-implicit-static-config.neon
@@ -1,0 +1,6 @@
+includes:
+    - ../../extension.neon
+
+parameters:
+    routeFiles:
+        - tests/ReturnTypes/stubs/routing/implicit/routes.php

--- a/tests/ReturnTypes/route-binding-precedence-config.neon
+++ b/tests/ReturnTypes/route-binding-precedence-config.neon
@@ -1,0 +1,9 @@
+includes:
+    - ../../vendor/larastan/larastan/extension.neon
+    - ../../extension.neon
+
+parameters:
+    routeBindingProviders:
+        - Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\PrecedenceRouteServiceProvider
+    routeFiles:
+        - tests/ReturnTypes/stubs/routing/implicit/routes.php

--- a/tests/ReturnTypes/stubs/routing/implicit/Controllers.php
+++ b/tests/ReturnTypes/stubs/routing/implicit/Controllers.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit;
+
+final class AdaptiveSubjectController
+{
+    // snake_case route param {adaptive_learning_subject} matches camelCase $adaptiveLearningSubject.
+    public function __invoke(Video $video, AdaptiveLearningSubject $adaptiveLearningSubject): void {}
+}
+
+final class ContainerController
+{
+    public function show(VideoContainer $videoContainer): void {}
+}
+
+final class VideoController
+{
+    public function edit(Video $video): void {}
+}
+
+final class AppleController
+{
+    public function __invoke(Apple $item): void {}
+}
+
+final class BananaController
+{
+    public function __invoke(Banana $item): void {}
+}
+
+final class UnhintedController
+{
+    public function __invoke(string $loose): void {}
+}

--- a/tests/ReturnTypes/stubs/routing/implicit/ImplicitRouteBindingStaticTarget.php
+++ b/tests/ReturnTypes/stubs/routing/implicit/ImplicitRouteBindingStaticTarget.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit;
+
+use Illuminate\Http\Request;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * The same implicit-binding resolution without larastan, so the skip cases assert a stable default
+ * route() type string (larastan's benevolent-union formatting varies by version).
+ */
+final class ImplicitRouteBindingStaticTarget
+{
+    public function exercise(Request $request): void
+    {
+        assertType('Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\Video', $request->route('video'));
+        assertType('Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\AdaptiveLearningSubject', $request->route('adaptive_learning_subject'));
+        assertType('Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\VideoContainer', $request->route('videoContainer'));
+        assertType('Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\Apple|Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\Banana', $request->route('item'));
+
+        // A closure action, a non-model type-hint, and an unknown parameter are not narrowed.
+        assertType('object|string|null', $request->route('ping'));
+        assertType('object|string|null', $request->route('loose'));
+        assertType('object|string|null', $request->route('unknown'));
+    }
+}

--- a/tests/ReturnTypes/stubs/routing/implicit/ImplicitRouteBindingTarget.php
+++ b/tests/ReturnTypes/stubs/routing/implicit/ImplicitRouteBindingTarget.php
@@ -22,10 +22,8 @@ final class ImplicitRouteBindingTarget
         // Same param bound to different models across routes → the union.
         assertType('Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\Apple|Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\Banana', $request->route('item'));
 
-        // A closure action, a non-model type-hint, and an unknown parameter are not narrowed.
-        // (Under larastan the default route() type prints as the parenthesised benevolent union.)
-        assertType('(object|string|null)', $request->route('ping'));
-        assertType('(object|string|null)', $request->route('loose'));
-        assertType('(object|string|null)', $request->route('unknown'));
+        // The skip/fail-safe cases (closure action, non-model hint, unknown parameter) assert the
+        // default route() type, whose larastan formatting varies by version — covered in the
+        // Laravel-only ImplicitRouteBindingStaticTarget instead, with a stable type string.
     }
 }

--- a/tests/ReturnTypes/stubs/routing/implicit/ImplicitRouteBindingTarget.php
+++ b/tests/ReturnTypes/stubs/routing/implicit/ImplicitRouteBindingTarget.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit;
+
+use Illuminate\Http\Request;
+
+use function PHPStan\Testing\assertType;
+
+final class ImplicitRouteBindingTarget
+{
+    public function exercise(Request $request): void
+    {
+        // Invokable controller __invoke param type-hint.
+        assertType(Video::class, $request->route('video'));
+
+        // snake_case route param resolved against the camelCase method param (Laravel's Str::snake rule).
+        assertType(AdaptiveLearningSubject::class, $request->route('adaptive_learning_subject'));
+
+        // [Controller::class, 'method'] array action.
+        assertType(VideoContainer::class, $request->route('videoContainer'));
+
+        // Same param bound to different models across routes → the union.
+        assertType('Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\Apple|Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\Banana', $request->route('item'));
+
+        // A closure action, a non-model type-hint, and an unknown parameter are not narrowed.
+        // (Under larastan the default route() type prints as the parenthesised benevolent union.)
+        assertType('(object|string|null)', $request->route('ping'));
+        assertType('(object|string|null)', $request->route('loose'));
+        assertType('(object|string|null)', $request->route('unknown'));
+    }
+}

--- a/tests/ReturnTypes/stubs/routing/implicit/Models.php
+++ b/tests/ReturnTypes/stubs/routing/implicit/Models.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit;
+
+use Illuminate\Database\Eloquent\Model;
+
+final class Video extends Model {}
+
+final class VideoContainer extends Model {}
+
+final class AdaptiveLearningSubject extends Model {}
+
+final class Apple extends Model {}
+
+final class Banana extends Model {}

--- a/tests/ReturnTypes/stubs/routing/implicit/PrecedenceRouteServiceProvider.php
+++ b/tests/ReturnTypes/stubs/routing/implicit/PrecedenceRouteServiceProvider.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit;
+
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\ServiceProvider;
+
+final class PrecedenceRouteServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        // Explicitly bind {video} to VideoContainer — the route file implicitly binds it to Video.
+        Route::model('video', VideoContainer::class);
+    }
+}

--- a/tests/ReturnTypes/stubs/routing/implicit/PrecedenceTarget.php
+++ b/tests/ReturnTypes/stubs/routing/implicit/PrecedenceTarget.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit;
+
+use Illuminate\Http\Request;
+
+use function PHPStan\Testing\assertType;
+
+final class PrecedenceTarget
+{
+    public function exercise(Request $request): void
+    {
+        // {video} is bound explicitly (Route::model → VideoContainer) and implicitly (route file → Video).
+        // The explicit binding wins.
+        assertType('Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\VideoContainer', $request->route('video'));
+
+        // A parameter with only an implicit binding still resolves through the fallback.
+        assertType('Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\AdaptiveLearningSubject', $request->route('adaptive_learning_subject'));
+    }
+}

--- a/tests/ReturnTypes/stubs/routing/implicit/routes.php
+++ b/tests/ReturnTypes/stubs/routing/implicit/routes.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+use Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\AdaptiveSubjectController;
+use Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\AppleController;
+use Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\BananaController;
+use Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\ContainerController;
+use Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\UnhintedController;
+use Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\VideoController;
+use Illuminate\Support\Facades\Route;
+
+// Invokable single-action controller (__invoke); snake_case route param ↔ camelCase method param.
+Route::patch('video/{video}/subjects/{adaptive_learning_subject}', AdaptiveSubjectController::class);
+
+// Array action [Controller::class, 'method'].
+Route::get('containers/{videoContainer}', [ContainerController::class, 'show']);
+
+// `match` puts the methods first, so the URI/action are shifted by one.
+Route::match(['get', 'post'], 'videos/{video}/edit', [VideoController::class, 'edit']);
+
+// Same route parameter bound to different models across routes — route('item') is their union.
+Route::get('apples/{item}', AppleController::class);
+Route::get('bananas/{item}', BananaController::class);
+
+// A closure action and a non-model type-hint are both skipped (not narrowed).
+Route::get('ping/{ping}', fn () => 'pong');
+Route::get('loose/{loose}', UnhintedController::class);


### PR DESCRIPTION
## Summary

Extends the route-model binding extension to also resolve Laravel **implicit** bindings — the ones derived from a controller's type-hint rather than declared with `Route::model()`/`Route::bind()`. This retires the residual `route('x')` + `assert($x instanceof Model)` pairs for parameters that are only bound implicitly.

It does this **statically** — no `route:list` manifest, and no booting your application at analysis time — by parsing the route files you list in a new `routeFiles` config. Off by default.

## How it works

`ImplicitRouteBindingResolver` reads each `Route::<verb>('uri/{param}', Action)` in the configured route files (invokable `Controller::class` → `__invoke`, or `[Controller::class, 'method']`), reflects the action parameter Laravel would bind to each route parameter — matched by name or `Str::snake()`, exactly as the framework's `ImplicitRouteBinding` does — keeps its type when it's a `Model`, and **unions** across every route that declares the parameter. Explicit provider bindings take precedence; implicit is the fallback.

It is **fail-safe**: closures, group-level controllers, `Route::resource`, non-model type-hints, and unreadable/missing files are skipped, leaving the default type. It never mis-types.

```neon
parameters:
    routeFiles:
        - routes/web.php
        - routes/api.php
```

## Why not a manifest / Ranger / Surveyor

`laravel/ranger` and `laravel/surveyor` expose this data but are **runtime** tools (they boot the app; Surveyor also opens a DB connection). A PHPStan extension can't boot the consumer's app during analysis — it would couple static analysis to a fully bootable app+env and re-pay that per parallel worker. Using them would mean dumping their output to a committed file (a manifest, with staleness). Static route-file parsing needs neither a manifest nor a boot, which is why it's the approach here. Ranger remains a sensible future opt-in *manifest source* (run in CI) for the resource/group routes this parser deliberately skips.

## Testing

- `composer test` — 261 passing / 338 assertions. New larastan-loaded tests cover invokable + array + `match` actions, snake-case matching, multi-route union, every skip/fail-safe case, and explicit-over-implicit precedence.
- Style, static analysis, and the full suite are clean (`composer qa`).

## Security & privacy

No security implications. Static-analysis-only; no runtime code path, no app boot.

## Risk assessment

**Medium.** Opt-in (no effect until `routeFiles` is set) and no new runtime dependency, but it adds a second resolution layer and a new config key. Behavior is fail-safe by construction and covered by the larastan-loaded regression suite. The non-null over-claim and `{param?}` caveat are identical to (and documented alongside) the explicit-binding behavior.
