### PR TITLE
Remove redundant NameResolver pass from route-binding parsing

### DIFF
--- a/src/ReturnTypes/ImplicitRouteBindingResolver.php
+++ b/src/ReturnTypes/ImplicitRouteBindingResolver.php
@@ -13,8 +13,6 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\NodeFinder;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\NameResolver;
 use PHPStan\Analyser\Scope;
 use PHPStan\Parser\Parser;
 use PHPStan\Parser\ParserErrorsException;
@@ -98,17 +96,13 @@ final class ImplicitRouteBindingResolver
         }
 
         try {
+            // The simple direct parser already runs name resolution (PHPStan's SimpleParser does),
+            // so facade/class names come back fully qualified — unlike the default analysis parser,
+            // whose facade static calls are unreliable once larastan is loaded.
             $statements = $this->parser->parseFile($routeFile);
         } catch (ParserErrorsException) {
             return [];
         }
-
-        // Simple direct parser does not resolve names, and is not the default analysis parser whose
-        // facade static calls are unreliable under larastan — resolve names ourselves.
-        $traverser = new NodeTraverser();
-        $traverser->addVisitor(new NameResolver());
-
-        $statements = $traverser->traverse($statements);
 
         return array_values((new NodeFinder())->findInstanceOf($statements, StaticCall::class));
     }

--- a/src/ReturnTypes/RouteBindingReturnTypeExtension.php
+++ b/src/ReturnTypes/RouteBindingReturnTypeExtension.php
@@ -18,8 +18,6 @@ use PhpParser\Node\NullableType;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\UnionType;
 use PhpParser\NodeFinder;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\NameResolver;
 use PHPStan\Analyser\Scope;
 use PHPStan\Parser\Parser;
 use PHPStan\Parser\ParserErrorsException;
@@ -166,18 +164,13 @@ final class RouteBindingReturnTypeExtension implements ExpressionTypeResolverExt
         }
 
         try {
+            // The simple direct parser already runs name resolution (PHPStan's SimpleParser does),
+            // so class names come back fully qualified — unlike the default analysis parser, whose
+            // facade static calls are not reliably exposed once larastan is loaded.
             $statements = $this->parser->parseFile($file);
         } catch (ParserErrorsException) {
             return [];
         }
-
-        // Resolve names to their FQCN. The injected parser is the simple direct parser, which does
-        // not run name resolution itself — and crucially is not the default analysis parser, whose
-        // facade static calls are not reliably exposed once larastan is loaded.
-        $traverser = new NodeTraverser();
-        $traverser->addVisitor(new NameResolver());
-
-        $statements = $traverser->traverse($statements);
 
         $bindings = [];
 


### PR DESCRIPTION
## Summary

Removes a redundant `NameResolver` traversal from both route-binding resolvers. PHPStan's `SimpleParser` — the `@currentPhpVersionSimpleDirectParser` injected into `RouteBindingReturnTypeExtension` and `ImplicitRouteBindingResolver` — already runs `NameResolver` internally (`src/Parser/SimpleParser.php`), so parsed class names come back fully qualified. The extra pass was a no-op, and the accompanying comment ("the simple direct parser does not run name resolution") was incorrect. Both removed.

Surfaced by a consumer integrating the Tier-2 sketch built on the same pattern.

## Testing

- `composer test` — 265 passing / 342 assertions (route-binding, implicit-binding incl. larastan-loaded, and relation tests all still resolve FQ names). Style, static analysis, full suite clean.

## Risk assessment

**Low.** Pure dead-code removal; no behavior change (the removed pass was idempotent on already-resolved names). Verified by the existing larastan-loaded regression suite.
