### PR TITLE
Add static/$this/self return marker to stubbedMethods

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,12 +260,16 @@ parameters:
         Illuminate\Testing\TestResponse:
             assertSeeLivewire: Illuminate\Testing\TestResponse
             fillForm: Illuminate\Testing\TestResponse
+        Laravel\Nova\Fields\Number:
+            onlyOnExport: '$this'
 ```
 
 Return types are parsed with PHPStan's type-string resolver, so any valid PHPDoc type works
-(`string`, `array<int, int>`, a class name for chainable assertions, etc.). Stubbed methods accept
-any arguments, so only the method name and its return type are modelled — argument types are not
-checked.
+(`string`, `array<int, int>`, a class name for chainable assertions, etc.). A return type of
+`$this`, `static`, or `self` is bound to the receiver, so a stubbed **fluent** method (a
+`$this`-returning macro, a chainable Nova field method) keeps its chain typed
+(`Number::make(…)->onlyOnExport()->sortable()`) instead of widening. Stubbed methods accept any
+arguments, so only the method name and its return type are modelled — argument types are not checked.
 
 ## Return type extensions
 

--- a/src/Reflection/StubbedMethodsClassReflectionExtension.php
+++ b/src/Reflection/StubbedMethodsClassReflectionExtension.php
@@ -7,6 +7,10 @@ use PHPStan\PhpDoc\TypeStringResolver;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StaticType;
+use PHPStan\Type\ThisType;
+use PHPStan\Type\Type;
 
 /**
  * Resolves instance methods that exist at runtime but not in PHPStan's reflection — Faker custom
@@ -14,7 +18,10 @@ use PHPStan\Reflection\MethodsClassReflectionExtension;
  * a typo'd method name (not in the configured set) still fails analysis. Instance methods only;
  * statically-called methods (e.g. facade __callStatic) are out of scope.
  *
- * Configure per consumer via the `stubbedMethods` parameter; nothing is resolved by default.
+ * Configure per consumer via the `stubbedMethods` parameter; nothing is resolved by default. A
+ * return type of `static`, `$this`, or `self` is bound to the receiver — so a stubbed fluent method
+ * (a `$this`-returning macro, a chainable Nova field method) keeps its chain typed instead of
+ * widening; any other value is parsed as a normal PHPDoc type string.
  */
 final class StubbedMethodsClassReflectionExtension implements MethodsClassReflectionExtension
 {
@@ -40,7 +47,21 @@ final class StubbedMethodsClassReflectionExtension implements MethodsClassReflec
         return new StubbedMethodReflection(
             $classReflection,
             $methodName,
-            $this->typeStringResolver->resolve($returnType),
+            $this->resolveReturnType($returnType, $classReflection),
         );
+    }
+
+    /**
+     * `static`/`$this` follow the receiver (late static binding) so fluent chains keep their type;
+     * `self` is the configured class exactly. Anything else is a PHPDoc type string.
+     */
+    private function resolveReturnType(string $returnType, ClassReflection $classReflection): Type
+    {
+        return match ($returnType) {
+            'static' => new StaticType($classReflection),
+            '$this' => new ThisType($classReflection),
+            'self' => new ObjectType($classReflection->getName()),
+            default => $this->typeStringResolver->resolve($returnType),
+        };
     }
 }

--- a/tests/Reflection/config.neon
+++ b/tests/Reflection/config.neon
@@ -7,3 +7,8 @@ parameters:
             customString: string
             customInt: int
             customList: 'array<int, int>'
+        Hihaho\PhpstanRules\Tests\Reflection\stubs\FluentStub:
+            thisChain: '$this'
+            staticChain: static
+            selfChain: self
+            label: string

--- a/tests/Reflection/stubs/StubbedMethodsTarget.php
+++ b/tests/Reflection/stubs/StubbedMethodsTarget.php
@@ -6,9 +6,24 @@ use function PHPStan\Testing\assertType;
 
 final class StubbedMethodsTarget {}
 
+final class FluentStub {}
+
 function exerciseStubbedMethods(StubbedMethodsTarget $target): void
 {
     assertType('string', $target->customString());
     assertType('int', $target->customInt());
     assertType('array<int, int>', $target->customList(5));
+}
+
+function exerciseFluentStubbedMethods(FluentStub $fluent): void
+{
+    // The `$this`, `static`, and `self` markers all return the receiver, so a stubbed fluent method
+    // keeps its type instead of widening to a bare string.
+    assertType(FluentStub::class, $fluent->thisChain());
+    assertType(FluentStub::class, $fluent->staticChain());
+    assertType(FluentStub::class, $fluent->selfChain());
+
+    // The chain keeps resolving the receiver's stubbed methods on the returned type.
+    assertType(FluentStub::class, $fluent->thisChain()->staticChain());
+    assertType('string', $fluent->thisChain()->label());
 }

--- a/tests/ReturnTypes/stubs/routing/implicit/Controllers.php
+++ b/tests/ReturnTypes/stubs/routing/implicit/Controllers.php
@@ -32,3 +32,8 @@ final class UnhintedController
 {
     public function __invoke(string $loose): void {}
 }
+
+final class OptionalVideoController
+{
+    public function __invoke(Video $optionalVideo): void {}
+}

--- a/tests/ReturnTypes/stubs/routing/implicit/ImplicitRouteBindingStaticTarget.php
+++ b/tests/ReturnTypes/stubs/routing/implicit/ImplicitRouteBindingStaticTarget.php
@@ -19,6 +19,9 @@ final class ImplicitRouteBindingStaticTarget
         assertType('Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\VideoContainer', $request->route('videoContainer'));
         assertType('Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\Apple|Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\Banana', $request->route('item'));
 
+        // An optional {param?} segment is narrowed to the non-null model (documented over-claim).
+        assertType('Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\Video', $request->route('optionalVideo'));
+
         // A closure action, a non-model type-hint, and an unknown parameter are not narrowed.
         assertType('object|string|null', $request->route('ping'));
         assertType('object|string|null', $request->route('loose'));

--- a/tests/ReturnTypes/stubs/routing/implicit/routes.php
+++ b/tests/ReturnTypes/stubs/routing/implicit/routes.php
@@ -4,6 +4,7 @@ use Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\AdaptiveSubject
 use Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\AppleController;
 use Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\BananaController;
 use Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\ContainerController;
+use Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\OptionalVideoController;
 use Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\UnhintedController;
 use Hihaho\PhpstanRules\Tests\ReturnTypes\stubs\routing\implicit\VideoController;
 use Illuminate\Support\Facades\Route;
@@ -20,6 +21,10 @@ Route::match(['get', 'post'], 'videos/{video}/edit', [VideoController::class, 'e
 // Same route parameter bound to different models across routes — route('item') is their union.
 Route::get('apples/{item}', AppleController::class);
 Route::get('bananas/{item}', BananaController::class);
+
+// An optional {param?} segment is resolved like a required one — the bound model is typed non-null
+// (the same over-claim as explicit bindings; documented).
+Route::get('optional/{optionalVideo?}', OptionalVideoController::class);
 
 // A closure action and a non-model type-hint are both skipped (not narrowed).
 Route::get('ping/{ping}', fn () => 'pong');


### PR DESCRIPTION
## Summary

`stubbedMethods` now understands `static`, `$this`, and `self` as return-type markers. A stubbed return type of `static`/`$this` binds to the receiver (late static binding) and `self` to the configured class — so a stubbed **fluent** method (a `$this`-returning macro, a chainable Nova field method like `onlyOnExport()`) keeps its chain typed instead of widening to a bare string.

This closes the gap a consumer hit: self-returning framework methods (`Number::onlyOnExport()`, `Relation::chaperone()`, …) couldn't be expressed as a fixed type string, so `stubbedMethods` couldn't resolve them and they stayed baselined.

```neon
parameters:
    stubbedMethods:
        Laravel\Nova\Fields\Number:
            onlyOnExport: '$this'   # Number::make(…)->onlyOnExport()->sortable() stays typed
```

## Implementation

`static` → `StaticType($classReflection)`, `$this` → `ThisType($classReflection)`, `self` → `ObjectType(class)`; anything else is parsed by the PHPDoc type-string resolver as before. Matching stays exact-class (no inheritance change), so existing behavior is untouched.

## Testing

- `composer test` — 271 passing / 348 assertions. New assertions cover each marker returning the receiver and a chained stubbed call staying typed (`->thisChain()->label()` → `string`). Also adds an optional-`{param?}` implicit-binding fixture pinning the documented non-null over-claim.
- Style, static analysis, full suite clean.

## Security & privacy

No security implications. Static-analysis-only.

## Risk assessment

**Low.** Purely additive — only changes how the three marker strings resolve; every other `stubbedMethods` value behaves exactly as before, and the feature is opt-in per configured method.
